### PR TITLE
[FIXED] Unable to reuse nested routers

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -262,9 +262,11 @@ Router.prototype.use = function () {
   middleware.forEach(function (m) {
     if (m.router) {
       m.router.stack.forEach(function (nestedLayer) {
-        if (path) nestedLayer.setPrefix(path);
-        if (router.opts.prefix) nestedLayer.setPrefix(router.opts.prefix);
-        router.stack.push(nestedLayer);
+        const cloneLayer = Object.assign(Object.create(Layer.prototype), nestedLayer);
+
+        if (path) cloneLayer.setPrefix(path);
+        if (router.opts.prefix) cloneLayer.setPrefix(router.opts.prefix);
+        router.stack.push(cloneLayer);
       });
 
       if (router.params) {


### PR DESCRIPTION
I understand the original author's mistakes. And I have been read the old issuse in ``ZijianHe/koa-router``. 

https://github.com/ZijianHe/koa-router/issues/244#issuecomment-363776228

So copy a new layer when calling router.use(path, ...fn). Shallow copy & inherit Layout.prototype is enough to solve this problem in safety.

This is an effective method.