### PR TITLE
`router.url` behaves unexpectedly for a named route that has no path parameters.

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -133,7 +133,7 @@ Layer.prototype.url = function (params, options) {
     }
   } else if (tokens.some(token => token.name)) {
     replace = params;
-  } else {
+  } else if (!options) {
     options = params;
   }
 

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1365,8 +1365,32 @@ describe('Router', function () {
     })
 
     it('generates URL for given route name without params and query params', function(done) {
-        const app = new Koa();
-        const router = new Router();
+        var router = new Router();
+        router.get('books', '/books', function (ctx) {
+          ctx.status = 204;
+        });
+        var url = router.url('books');
+        url.should.equal('/books');
+        var url = router.url('books');
+        url.should.equal('/books', {});
+        var url = router.url('books');
+        url.should.equal('/books', {}, {});
+        var url = router.url('books',
+          {},
+          { query: { page: 3, limit: 10 } }
+        );
+        url.should.equal('/books?page=3&limit=10');
+        var url = router.url('books',
+          {},
+          { query: 'page=3&limit=10' }
+        );
+        url.should.equal('/books?page=3&limit=10');
+        done();
+    })
+
+
+    it('generates URL for given route name without params and query params', function(done) {
+        var router = new Router();
         router.get('category', '/category', function (ctx) {
           ctx.status = 204;
         });


### PR DESCRIPTION
`router.url` behaves unexpectedly for a named route that has no path parameters.

See da1ab1f for the failing test - CI https://travis-ci.org/koajs/router/builds/614446723

Following the [docs](https://github.com/koajs/router/blob/master/API.md#module_koa-router--Router+url)

```js
router.get('books', '/books', function (ctx) {
  ctx.status = 204;
});

var url = router.url('books',
  {},
  { query: 'page=3&limit=10' }
);
// actual "/books"
// expected // actual "/books?page=3&limit=10"
```

06052cb fixes the tests but i fear it may have unintended side effects, it'd be better if someone with knowledge of the library took a look at this.

The workaround for 8.0.2 is to pass it like so, omitting the second argument which shouldn't be optional according to the docs.

```js
var url = router.url('books',
  { query: 'page=3&limit=10' }
);
// actual "/books?page=3&limit=10"
```

Alternatively, fix the docs. As-is i can't rely on `@koa/router` because if this gets fixed my integration would break.