### PR TITLE
Refactor/for each to forloops

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -25,12 +25,19 @@ function Layer(path, methods, middleware, opts) {
   this.paramNames = [];
   this.stack = Array.isArray(middleware) ? middleware : [middleware];
 
-  methods.forEach(function(method) {
-    var l = this.methods.push(method.toUpperCase());
+  //! Will remove after all conversions are confirmed in PR 
+  //* methods.forEach(function(method) {
+  //*   var l = this.methods.push(method.toUpperCase());
+  //*   if (this.methods[l-1] === 'GET') {
+  //*     this.methods.unshift('HEAD');
+  //*   }
+  //* }, this);
+  for(var i = 0; i < methods.length; i++) {
+    var l = this.methods.push(methods[i].toUpperCase());
     if (this.methods[l-1] === 'GET') {
-      this.methods.unshift('HEAD');
+       this.methods.unshift('HEAD');
     }
-  }, this);
+  }
 
   // ensure middleware is a function
   this.stack.forEach(function(fn) {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -32,8 +32,8 @@ function Layer(path, methods, middleware, opts) {
   //*     this.methods.unshift('HEAD');
   //*   }
   //* }, this);
-  for(let i = 0; i < methods.length; i++) {
-    let l = this.methods.push(methods[i].toUpperCase());
+  for(var i = 0; i < methods.length; i++) {
+    var l = this.methods.push(methods[i].toUpperCase());
     if (this.methods[l-1] === 'GET') {
        this.methods.unshift('HEAD');
     }
@@ -49,9 +49,9 @@ function Layer(path, methods, middleware, opts) {
         //   }
         // }, this);
   // ensure middleware is a function
-  for (let i = 0; i < this.stack.length; i++) {
-    const fn = this.stack[i];
-    let type = (typeof fn);
+  for (var i = 0; i < this.stack.length; i++) {
+    var fn = this.stack[i];
+    var type = (typeof fn);
     if (type !== 'function') {
       throw new Error(
         methods.toString() + " `" + (this.opts.name || path) +"`: `middleware` "

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -25,13 +25,6 @@ function Layer(path, methods, middleware, opts) {
   this.paramNames = [];
   this.stack = Array.isArray(middleware) ? middleware : [middleware];
 
-  //! Will remove after all conversions are confirmed in PR 
-  //* methods.forEach(function(method) {
-  //*   var l = this.methods.push(method.toUpperCase());
-  //*   if (this.methods[l-1] === 'GET') {
-  //*     this.methods.unshift('HEAD');
-  //*   }
-  //* }, this);
   for(var i = 0; i < methods.length; i++) {
     var l = this.methods.push(methods[i].toUpperCase());
     if (this.methods[l-1] === 'GET') {
@@ -39,15 +32,6 @@ function Layer(path, methods, middleware, opts) {
     }
   }
 
-  // this.stack.forEach(function(fn) {
-    //   var type = (typeof fn);
-    //   if (type !== 'function') {
-      //     throw new Error(
-        //       methods.toString() + " `" + (this.opts.name || path) +"`: `middleware` "
-        //       + "must be a function, not `" + type + "`"
-        //     );
-        //   }
-        // }, this);
   // ensure middleware is a function
   for (var i = 0; i < this.stack.length; i++) {
     var fn = this.stack[i];

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -32,23 +32,33 @@ function Layer(path, methods, middleware, opts) {
   //*     this.methods.unshift('HEAD');
   //*   }
   //* }, this);
-  for(var i = 0; i < methods.length; i++) {
-    var l = this.methods.push(methods[i].toUpperCase());
+  for(let i = 0; i < methods.length; i++) {
+    let l = this.methods.push(methods[i].toUpperCase());
     if (this.methods[l-1] === 'GET') {
        this.methods.unshift('HEAD');
     }
   }
 
+  // this.stack.forEach(function(fn) {
+    //   var type = (typeof fn);
+    //   if (type !== 'function') {
+      //     throw new Error(
+        //       methods.toString() + " `" + (this.opts.name || path) +"`: `middleware` "
+        //       + "must be a function, not `" + type + "`"
+        //     );
+        //   }
+        // }, this);
   // ensure middleware is a function
-  this.stack.forEach(function(fn) {
-    var type = (typeof fn);
+  for (let i = 0; i < this.stack.length; i++) {
+    const fn = this.stack[i];
+    let type = (typeof fn);
     if (type !== 'function') {
       throw new Error(
         methods.toString() + " `" + (this.opts.name || path) +"`: `middleware` "
         + "must be a function, not `" + type + "`"
       );
     }
-  }, this);
+  }
 
   this.path = path;
   this.regexp = pathToRegExp(path, this.paramNames, this.opts);

--- a/lib/router.js
+++ b/lib/router.js
@@ -437,7 +437,7 @@ Router.prototype.allowedMethods = function (options) {
               allowed[method] = method
           }
         }
-        
+
         var allowedArr = Object.keys(allowed);
 
         if (!~implemented.indexOf(ctx.method)) {
@@ -566,9 +566,10 @@ Router.prototype.register = function (path, methods, middleware, opts) {
 
   // support array of paths
   if (Array.isArray(path)) {
-    path.forEach(function (p) {
-      router.register.call(router, p, methods, middleware, opts);
-    });
+    for (let i = 0; i < path.length; i++) {
+      const curPath = path[i];
+      router.register.call(router, curPath, methods, middleware, opts);
+    }
 
     return this;
   }

--- a/lib/router.js
+++ b/lib/router.js
@@ -270,24 +270,28 @@ Router.prototype.use = function () {
         stack: m.router.stack.slice(0)
       });
 
-      cloneRouter.stack.forEach(function (nestedLayer, index) {
-        var cloneLayer = Object.assign(Object.create(Layer.prototype), nestedLayer);
+      for (var i = 0; i < cloneRouter.stack.length; i++) {
+        var nestedLayer = cloneRouter.stack[i];
+        var cloneLayer = Object.assign(
+          Object.create(Layer.prototype),
+          nestedLayer
+        );
 
         if (path) cloneLayer.setPrefix(path);
         if (router.opts.prefix) cloneLayer.setPrefix(router.opts.prefix);
         router.stack.push(cloneLayer);
-        this[index] = cloneLayer;
-      }, cloneRouter.stack);
+        cloneRouter.stack[i] = cloneLayer;
+      }
 
       if (router.params) {
-        function setRouterParams(paramArr){
-        var routerParams = paramArr
-        for (var i = 0; i < routerParams.length; i++) {
-          var key = routerParams[i];
-          cloneRouter.param(key, router.params[key]);
+        function setRouterParams(paramArr) {
+          var routerParams = paramArr;
+          for (var i = 0; i < routerParams.length; i++) {
+            var key = routerParams[i];
+            cloneRouter.param(key, router.params[key]);
+          }
         }
-      }
-      setRouterParams(Object.keys(router.params))
+        setRouterParams(Object.keys(router.params));
       }
     } else {
       router.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });

--- a/lib/router.js
+++ b/lib/router.js
@@ -276,9 +276,14 @@ Router.prototype.use = function () {
       }, cloneRouter.stack);
 
       if (router.params) {
-        Object.keys(router.params).forEach(function (key) {
+        function routerParams(paramArr){
+        var routerParams = paramArr
+        for (var i = 0; i < routerParams.length; i++) {
+          var key = routerParams[i];
           cloneRouter.param(key, router.params[key]);
-        });
+        }
+      }
+      routerParams(Object.keys(router.params))
       }
     } else {
       router.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });

--- a/lib/router.js
+++ b/lib/router.js
@@ -731,11 +731,13 @@ Router.prototype.match = function (path, method) {
  * @returns {Router}
  */
 
-Router.prototype.param = function (param, middleware) {
+Router.prototype.param = function(param, middleware) {
   this.params[param] = middleware;
-  this.stack.forEach(function (route) {
+  for (var i = 0; i < this.stack.length; i++) {
+    var route = this.stack[i];
     route.param(param, middleware);
-  });
+  }
+
   return this;
 };
 
@@ -753,7 +755,7 @@ Router.prototype.param = function (param, middleware) {
  * @param {Object} params url parameters
  * @returns {String}
  */
-Router.url = function (path, params) {
+Router.url = function (path) {
     var args = Array.prototype.slice.call(arguments, 1);
     return Layer.prototype.url.apply({ path: path }, args);
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -430,12 +430,14 @@ Router.prototype.allowedMethods = function (options) {
       var allowed = {};
 
       if (!ctx.status || ctx.status === 404) {
-        ctx.matched.forEach(function (route) {
-          route.methods.forEach(function (method) {
-            allowed[method] = method;
-          });
-        });
-
+        for (var i = 0; i < ctx.matched.length; i++) {
+          var route = ctx.matched[i];
+          for (var j = 0; j < route.methods.length; j++) {
+            var method = route.methods[j];
+              allowed[method] = method
+          }
+        }
+        
         var allowedArr = Object.keys(allowed);
 
         if (!~implemented.indexOf(ctx.method)) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -259,14 +259,15 @@ Router.prototype.use = function () {
     path = middleware.shift();
   }
 
-  middleware.forEach(function (m) {
+  for (var i = 0; i < middleware.length; i++) {
+    var m = middleware[i];
     if (m.router) {
-      const cloneRouter = Object.assign(Object.create(Router.prototype), m.router, {
+      var cloneRouter = Object.assign(Object.create(Router.prototype), m.router, {
         stack: m.router.stack.slice(0)
       });
 
       cloneRouter.stack.forEach(function (nestedLayer, index) {
-        const cloneLayer = Object.assign(Object.create(Layer.prototype), nestedLayer);
+        var cloneLayer = Object.assign(Object.create(Layer.prototype), nestedLayer);
 
         if (path) cloneLayer.setPrefix(path);
         if (router.opts.prefix) cloneLayer.setPrefix(router.opts.prefix);
@@ -282,7 +283,7 @@ Router.prototype.use = function () {
     } else {
       router.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });
     }
-  });
+  }
 
   return this;
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -276,14 +276,14 @@ Router.prototype.use = function () {
       }, cloneRouter.stack);
 
       if (router.params) {
-        function routerParams(paramArr){
+        function setRouterParams(paramArr){
         var routerParams = paramArr
         for (var i = 0; i < routerParams.length; i++) {
           var key = routerParams[i];
           cloneRouter.param(key, router.params[key]);
         }
       }
-      routerParams(Object.keys(router.params))
+      setRouterParams(Object.keys(router.params))
       }
     } else {
       router.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });
@@ -311,10 +311,11 @@ Router.prototype.prefix = function (prefix) {
 
   this.opts.prefix = prefix;
 
-  this.stack.forEach(function (route) {
+  for (var i = 0; i < this.stack.length; i++) {
+    var route = this.stack[i];
     route.setPrefix(prefix);
-  });
-
+  }
+  
   return this;
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -566,8 +566,8 @@ Router.prototype.register = function (path, methods, middleware, opts) {
 
   // support array of paths
   if (Array.isArray(path)) {
-    for (let i = 0; i < path.length; i++) {
-      const curPath = path[i];
+    for (var i = 0; i < path.length; i++) {
+      var curPath = path[i];
       router.register.call(router, curPath, methods, middleware, opts);
     }
 
@@ -589,9 +589,10 @@ Router.prototype.register = function (path, methods, middleware, opts) {
   }
 
   // add parameter middleware
-  Object.keys(this.params).forEach(function (param) {
+  for (var i = 0; i < Object.keys(this.params).length; i++) {
+    var param = Object.keys(this.params)[i];
     route.param(param, this.params[param]);
-  }, this);
+  }
 
   stack.push(route);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -187,25 +187,28 @@ function Router(opts) {
  * @returns {Router}
  */
 
-methods.forEach(function (method) {
-  Router.prototype[method] = function (name, path, middleware) {
-    var middleware;
+for (var i = 0; i < methods.length; i++) {
+  function setMethodVerb(method) {
+    Router.prototype[method] = function(name, path, middleware) {
+      var middleware;
 
-    if (typeof path === 'string' || path instanceof RegExp) {
-      middleware = Array.prototype.slice.call(arguments, 2);
-    } else {
-      middleware = Array.prototype.slice.call(arguments, 1);
-      path = name;
-      name = null;
-    }
+      if (typeof path === "string" || path instanceof RegExp) {
+        middleware = Array.prototype.slice.call(arguments, 2);
+      } else {
+        middleware = Array.prototype.slice.call(arguments, 1);
+        path = name;
+        name = null;
+      }
 
-    this.register(path, [method], middleware, {
-      name: name
-    });
+      this.register(path, [method], middleware, {
+        name: name
+      });
 
-    return this;
-  };
-});
+      return this;
+    };
+  }
+  setMethodVerb(methods[i]);
+}
 
 // Alias for `router.delete()` because delete is a reserved word
 Router.prototype.del = Router.prototype['delete'];
@@ -247,10 +250,11 @@ Router.prototype.use = function () {
 
   // support array of paths
   if (Array.isArray(middleware[0]) && typeof middleware[0][0] === 'string') {
-    middleware[0].forEach(function (p) {
+    var arrPaths = middleware[0];
+    for (var i = 0; i < arrPaths.length; i++) {
+      var p = arrPaths[i];
       router.use.apply(router, [p].concat(middleware.slice(1)));
-    });
-
+    }
     return this;
   }
 


### PR DESCRIPTION
- forEach on methods converted to ES1 `for` loop - leaving comments for PR review confirmation
  - Once the PR has been reviewed and the logic is confirmed I will remove the commented out `forEach` logic. 
- forEach converted to `for` loop -- function ensures middleware is a function
- let & const to var for potential small perf -- tests passing in both prior commits 

should resolve #42 
<img width="762" alt="Screen Shot 2020-02-01 at 8 42 15 PM" src="https://user-images.githubusercontent.com/27247160/73602091-5e8a6c00-4533-11ea-9986-9468e149e631.png">
