### PR TITLE
Dynamic Variables and Improved Benchmark files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.fontFamily": "'Fira Code', Menlo, Monaco, 'Courier New', monospace"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.fontFamily": "'Fira Code', Menlo, Monaco, 'Courier New', monospace"
-}

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,8 +1,8 @@
 all: middleware
 
 middleware:
-	@sh ./run 5 false
 	@sh ./run 1 false
+	@sh ./run 5 false
 	@sh ./run 10 false
 	@sh ./run 20 false
 	@sh ./run 50 false

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,23 +1,23 @@
 all: middleware
 
 middleware:
-	 ./run 5 false
-	 ./run 1 false
-	 ./run 10 false
-	 ./run 20 false
-	 ./run 50 false
-	 ./run 100 false
-	 ./run 200 false
-	 ./run 500 false
-	 ./run 1000 false
-	 ./run 1 true
-	 ./run 5 true
-	 ./run 10 true
-	 ./run 20 true
-	 ./run 50 true
-	 ./run 100 true
-	 ./run 200 true
-	 ./run 500 true
-	 ./run 1000 true
+	@sh ./run 5 false
+	@sh ./run 1 false
+	@sh ./run 10 false
+	@sh ./run 20 false
+	@sh ./run 50 false
+	@sh ./run 100 false
+	@sh ./run 200 false
+	@sh ./run 500 false
+	@sh ./run 1000 false
+	@sh ./run 1 true
+	@sh ./run 5 true
+	@sh ./run 10 true
+	@sh ./run 20 true
+	@sh ./run 50 true
+	@sh ./run 100 true
+	@sh ./run 200 true
+	@sh ./run 500 true
+	@sh ./run 1000 true
 
 .PHONY: all middleware

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,23 +1,23 @@
 all: middleware
 
 middleware:
-	@./run 1 false
-	@./run 5 false
-	@./run 10 false
-	@./run 20 false
-	@./run 50 false
-	@./run 100 false
-	@./run 200 false
-	@./run 500 false
-	@./run 1000 false
-	@./run 1 true
-	@./run 5 true
-	@./run 10 true
-	@./run 20 true
-	@./run 50 true
-	@./run 100 true
-	@./run 200 true
-	@./run 500 true
-	@./run 1000 true
+	 ./run 5 false
+	 ./run 1 false
+	 ./run 10 false
+	 ./run 20 false
+	 ./run 50 false
+	 ./run 100 false
+	 ./run 200 false
+	 ./run 500 false
+	 ./run 1000 false
+	 ./run 1 true
+	 ./run 5 true
+	 ./run 10 true
+	 ./run 20 true
+	 ./run 50 true
+	 ./run 100 true
+	 ./run 200 true
+	 ./run 500 true
+	 ./run 1000 true
 
 .PHONY: all middleware

--- a/bench/run
+++ b/bench/run
@@ -5,7 +5,6 @@ set -e
 set -o allexport; source "$(dirname $0)/../.env"; set +o allexport
 export FACTOR=$1
 export USE_MIDDLEWARE=$2
-printenv
 echo "Environment Set"
 
 echo "Starting server on PORT:$PORT"
@@ -13,7 +12,6 @@ host="http://localhost:$PORT"
 
 node "$(dirname $0)/server.js" &
 
-wait $!
 pid=$!
 
 curl \
@@ -34,3 +32,4 @@ wrk "$host/10/child/grandchild/%40" \
 
 echo "Killed Port $PORT on PID $pid"
 kill $pid 
+exit

--- a/bench/run
+++ b/bench/run
@@ -1,14 +1,19 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
+echo "Setting Environment..."
 set -e
-
+set -o allexport; source "$(dirname $0)/../.env"; set +o allexport
 export FACTOR=$1
 export USE_MIDDLEWARE=$2
+printenv
+echo "Environment Set"
 
-host="http://localhost:3333"
+echo "Starting server on PORT:$PORT"
+host="http://localhost:$PORT"
 
 node "$(dirname $0)/server.js" &
 
+wait $!
 pid=$!
 
 curl \
@@ -27,4 +32,5 @@ wrk "$host/10/child/grandchild/%40" \
   | grep 'Requests/sec' \
   | awk '{ print "  " $2 }'
 
-kill $pid
+echo "Killed Port $PORT on PID $pid"
+kill $pid 

--- a/bench/run
+++ b/bench/run
@@ -1,13 +1,10 @@
 #!/bin/env bash
 
-echo "Setting Environment..."
 set -e
 set -o allexport; source "$(dirname $0)/../.env"; set +o allexport
 export FACTOR=$1
 export USE_MIDDLEWARE=$2
-echo "Environment Set"
 
-echo "Starting server on PORT:$PORT"
 host="http://localhost:$PORT"
 
 node "$(dirname $0)/server.js" &
@@ -30,6 +27,5 @@ wrk "$host/10/child/grandchild/%40" \
   | grep 'Requests/sec' \
   | awk '{ print "  " $2 }'
 
-echo "Killed Port $PORT on PID $pid"
 kill $pid 
 exit

--- a/bench/server.js
+++ b/bench/server.js
@@ -1,12 +1,14 @@
 const Koa = require('koa');
 const Router = require('../');
+const env = require('@ladjs/env')({path:'../.env', includeProcessEnv: true,
+assignToProcessEnv: true,});
 
 const app = new Koa();
 const router = new Router();
 
 const ok = ctx => ctx.status = 200;
-const n = parseInt(process.env.FACTOR || '10', 10);
-const useMiddleware = process.env.USE_MIDDLEWARE === 'true';
+const n = parseInt(env.FACTOR || '10', 10);
+const useMiddleware = env.USE_MIDDLEWARE === 'true';
 
 router.get('/_health', ok);
 
@@ -44,4 +46,4 @@ app.use(router.routes());
 
 process.stdout.write(`mw: ${useMiddleware} factor: ${n}`);
 
-app.listen(3333);
+app.listen(env.PORT);

--- a/bench/server.js
+++ b/bench/server.js
@@ -44,6 +44,6 @@ if (process.env.DEBUG) {
 
 app.use(router.routes());
 
-process.stdout.write(`mw: ${useMiddleware} factor: ${n}`);
+process.stdout.write(`mw: ${useMiddleware} factor: ${n} requests/sec`);
 
 app.listen(env.PORT);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "urijs": "^1.19.2"
   },
   "devDependencies": {
+    "@ladjs/env": "^1.0.0",
     "expect.js": "^0.3.1",
     "jsdoc-to-markdown": "^5.0.3",
     "koa": "^2.11.0",


### PR DESCRIPTION
- Modified the make file to specifically execute `sh` on the `run` file which is set to be a `bash` file ecosystem.
- Set the environments in the `bash` run file utilizing a `.env` file for PORT, however, a fallback PORT can also be added. (waiting on an opinion if not necessary then-current configurations, meaning .env file needed for benchmarking should be added to documentation) 
- based on @niftylettuce suggestion used the `ladjs/env` for the *server.js* file to be able to use both the `.env` and the bash file exported variables to local environment. 

resolves #56 