### PR TITLE
Upgrade path to regexp

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -215,7 +215,11 @@ Layer.prototype.param = function (param, fn) {
 
 Layer.prototype.setPrefix = function (prefix) {
   if (this.path) {
-    this.path = prefix + this.path;
+    if (this.path !== '/' || this.opts.strict === true) {
+      this.path = prefix + this.path;
+    } else {
+      this.path = prefix;
+    }
     this.paramNames = [];
     this.regexp = pathToRegexp(this.path, this.paramNames, this.opts);
   }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -117,8 +117,6 @@ Layer.prototype.captures = function (path) {
 Layer.prototype.url = function (params, options) {
   var args = params;
   var url = this.path.replace(/\(\.\*\)/g, '');
-  var toPath = compile(url);
-  var replaced;
 
   if (typeof params != 'object') {
     args = Array.prototype.slice.call(arguments);
@@ -127,6 +125,9 @@ Layer.prototype.url = function (params, options) {
       args = args.slice(0, args.length - 1);
     }
   }
+
+  var toPath = compile(url, options);
+  var replaced;
 
   var tokens = parse(url);
   var replace = {};

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,5 +1,5 @@
 var debug = require('debug')('koa-router');
-var pathToRegExp = require('path-to-regexp');
+var { pathToRegexp, compile, parse } = require('path-to-regexp');
 var uri = require('urijs');
 
 module.exports = Layer;
@@ -45,7 +45,7 @@ function Layer(path, methods, middleware, opts) {
   }
 
   this.path = path;
-  this.regexp = pathToRegExp(path, this.paramNames, this.opts);
+  this.regexp = pathToRegexp(path, this.paramNames, this.opts);
 
   debug('defined route %s %s', this.methods, this.opts.prefix + this.path);
 };
@@ -117,7 +117,7 @@ Layer.prototype.captures = function (path) {
 Layer.prototype.url = function (params, options) {
   var args = params;
   var url = this.path.replace(/\(\.\*\)/g, '');
-  var toPath = pathToRegExp.compile(url);
+  var toPath = compile(url);
   var replaced;
 
   if (typeof params != 'object') {
@@ -128,7 +128,7 @@ Layer.prototype.url = function (params, options) {
     }
   }
 
-  var tokens = pathToRegExp.parse(url);
+  var tokens = parse(url);
   var replace = {};
 
   if (args instanceof Array) {
@@ -216,7 +216,7 @@ Layer.prototype.setPrefix = function (prefix) {
   if (this.path) {
     this.path = prefix + this.path;
     this.paramNames = [];
-    this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);
+    this.regexp = pathToRegexp(this.path, this.paramNames, this.opts);
   }
 
   return this;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "http-errors": "^1.7.3",
     "koa-compose": "^4.1.0",
     "methods": "^1.1.2",
-    "path-to-regexp": "1.x",
+    "path-to-regexp": "^6.1.0",
     "urijs": "^1.19.2"
   },
   "devDependencies": {

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -218,7 +218,7 @@ describe('Layer', function() {
     });
 
     it('param with paramNames positive check', function () {
-      var route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
+      var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
       route.paramNames = [{
         name: 'category',
       }]
@@ -230,7 +230,7 @@ describe('Layer', function() {
 
   describe('Layer#url()', function() {
     it('generates route URL', function() {
-      var route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
+      var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
       var url = route.url({ category: 'programming', title: 'how-to-node' });
       url.should.equal('/programming/how-to-node');
       url = route.url('programming', 'how-to-node');
@@ -238,12 +238,12 @@ describe('Layer', function() {
     });
 
     it('escapes using encodeURIComponent()', function() {
-      var route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
+      var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
       var url = route.url({ category: 'programming', title: 'how to node' });
       url.should.equal('/programming/how%20to%20node');
     });
     it('setPrefix method checks Layer for path', function () {
-      const route = new Layer('/category', ['get'], [function () {}], 'books');
+      const route = new Layer('/category', ['get'], [function () {}], {name: 'books'});
       route.path = '/hunter2'
       const prefix = route.setPrefix('TEST')
       prefix.path.should.equal('TEST/hunter2')

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -239,7 +239,10 @@ describe('Layer', function() {
 
     it('escapes using encodeURIComponent()', function() {
       var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
-      var url = route.url({ category: 'programming', title: 'how to node' });
+      var url = route.url(
+        { category: 'programming', title: 'how to node' },
+        { encode: encodeURIComponent }
+      );
       url.should.equal('/programming/how%20to%20node');
     });
     it('setPrefix method checks Layer for path', function () {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1107,7 +1107,7 @@ describe('Router', function () {
         done();
       }, error => done(error));
     });
-    
+
     it('uses a same router middleware at given paths continuously - ZijianHe/koa-router#gh-244 gh-18', function (done) {
       const app = new Koa();
       const base = new Router({ prefix: '/api' });
@@ -1234,7 +1234,7 @@ describe('Router', function () {
       });
       url.should.equal('/programming/how%20to%20node');
       done();
-      
+
     });
 
     it('generates URL for given route name within embedded routers', function (done) {
@@ -1852,6 +1852,61 @@ describe('Router', function () {
         });
       }
     }
+
+    it(`prefix and '/' route behavior`, function(done) {
+      var app = new Koa();
+      var router = new Router({
+        strict: false,
+        prefix: '/foo'
+      });
+
+      var strictRouter = new Router({
+        strict: true,
+        prefix: '/bar'
+      })
+
+      router.get('/', function(ctx) {
+        ctx.body = '';
+      });
+
+      strictRouter.get('/', function(ctx) {
+        ctx.body = '';
+      });
+
+      app.use(router.routes());
+      app.use(strictRouter.routes());
+
+      var server = http.createServer(app.callback());
+
+      request(server)
+        .get('/foo')
+        .expect(200)
+        .end(function (err) {
+          if (err) return done(err);
+
+          request(server)
+            .get('/foo/')
+            .expect(200)
+            .end(function (err) {
+              if (err) return done(err);
+
+              request(server)
+                .get('/bar')
+                .expect(404)
+                .end(function (err) {
+                  if (err) return done(err);
+
+                  request(server)
+                    .get('/bar/')
+                    .expect(200)
+                    .end(function (err) {
+                      if (err) return done(err);
+                      done();
+                    });
+                });
+            });
+        });
+    })
   });
 
   describe('Static Router#url()', function () {

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1223,9 +1223,15 @@ describe('Router', function () {
       router.get('books', '/:category/:title', function (ctx) {
         ctx.status = 204;
       });
-      var url = router.url('books', { category: 'programming', title: 'how to node' });
+      var url = router.url(
+        'books',
+        { category: 'programming', title: 'how to node' },
+        { encode: encodeURIComponent }
+      );
       url.should.equal('/programming/how%20to%20node');
-      url = router.url('books', 'programming', 'how to node');
+      url = router.url('books', 'programming', 'how to node', {
+        encode: encodeURIComponent,
+      });
       url.should.equal('/programming/how%20to%20node');
       done();
       
@@ -1245,9 +1251,15 @@ describe('Router', function () {
         });
         router.use(embeddedRouter.routes());
         app.use(router.routes());
-        var url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
+        var url = router.url(
+            'chapters',
+            { chapterName: 'Learning ECMA6', pageNumber: 123 },
+            { encode: encodeURIComponent }
+        );
         url.should.equal('/books/chapters/Learning%20ECMA6/123');
-        url = router.url('chapters', 'Learning ECMA6', 123);
+        url = router.url('chapters', 'Learning ECMA6', 123, {
+            encode: encodeURIComponent,
+        });
         url.should.equal('/books/chapters/Learning%20ECMA6/123');
         done();
     });
@@ -1269,7 +1281,11 @@ describe('Router', function () {
       embeddedRouter.use(embeddedRouter2.routes());
       router.use(embeddedRouter.routes());
       app.use(router.routes());
-      var url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
+      var url = router.url(
+        'chapters',
+        { chapterName: 'Learning ECMA6', pageNumber: 123 },
+        { encode: encodeURIComponent }
+      );
       url.should.equal('/books/chapters/Learning%20ECMA6/pages/123');
       done();
     });
@@ -1845,7 +1861,11 @@ describe('Router', function () {
     });
 
     it('escapes using encodeURIComponent()', function () {
-      var url = Router.url('/:category/:title', { category: 'programming', title: 'how to node' });
+      var url = Router.url(
+        '/:category/:title',
+        { category: 'programming', title: 'how to node' },
+        { encode: encodeURIComponent }
+      );
       url.should.equal('/programming/how%20to%20node');
     });
 


### PR DESCRIPTION
Upgrade `path-to-regexp` from 1.x to ^6.x

then:
- https://github.com/koajs/router/commit/ff31e4b355bbb732ffd87605542eb3d76986aa70 to fix tests only
- https://github.com/koajs/router/commit/78a292925594f6acb6def50723094467e7c2c413 to deal with `path-to-regexp` encode/decode being by default the identity function `x => x` ... send the options to `compile` and be explicit in the tests
- https://github.com/koajs/router/commit/5fcc2ed01a377fe935e0b540226ddc8ab11b53d3 be explicit in the router url tests
- https://github.com/koajs/router/commit/e047222f10a63dc9cf57815f9a2697772a44748b deal with the `path-to-regexp@2.0` breaking change regarding explicit trailing slash handling https://github.com/pillarjs/path-to-regexp/blob/0c466b1b0944e8d0022b5b15069364a8483bf9c5/History.md#200--2017-08-23 ... I added tests, it should not be a breaking change for us because I added a specific behavior when `path === '/'` and prefix, we can target trailing slash by using the strict option.

should fixes #40 

should be a straight upgrade over https://github.com/koajs/router/pull/70

Maybe breaking change (major semver) related to the encode/decode situation.