### PR TITLE
refactor(dependencies): remove urijs dependency

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,6 +1,6 @@
 var debug = require('debug')('koa-router');
 var { pathToRegexp, compile, parse } = require('path-to-regexp');
-var uri = require('urijs');
+var { parse: parseUrl, format: formatUrl } = require('url');
 
 module.exports = Layer;
 
@@ -145,9 +145,14 @@ Layer.prototype.url = function (params, options) {
   replaced = toPath(replace);
 
   if (options && options.query) {
-    var replaced = new uri(replaced)
-    replaced.search(options.query);
-    return replaced.toString();
+    replaced = parseUrl(replaced)
+    if (typeof options.query === 'string') {
+      replaced.search = options.query
+    } else {
+      replaced.search = undefined
+      replaced.query = options.query
+    }
+    return formatUrl(replaced)
   }
 
   return replaced;

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "http-errors": "^1.7.3",
     "koa-compose": "^4.1.0",
     "methods": "^1.1.2",
-    "path-to-regexp": "^6.1.0",
-    "urijs": "^1.19.2"
+    "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
     "@ladjs/env": "^1.0.0",


### PR DESCRIPTION
Removes the (imho unnecessary) dependency on userland `urijs` module. I wanted to use the WHATWG `URL` API but alas that one does not support relative URLs.