### PR TITLE
feat: replace var with const and let

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "9"
   - "10"
   - "11"
+  - "12"
 notifications:
   email:
     on_success: never

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,6 +1,6 @@
-var debug = require('debug')('koa-router');
-var { pathToRegexp, compile, parse } = require('path-to-regexp');
-var uri = require('urijs');
+const debug = require('debug')('koa-router');
+const { pathToRegexp, compile, parse } = require('path-to-regexp');
+const uri = require('urijs');
 
 module.exports = Layer;
 
@@ -25,17 +25,17 @@ function Layer(path, methods, middleware, opts) {
   this.paramNames = [];
   this.stack = Array.isArray(middleware) ? middleware : [middleware];
 
-  for(var i = 0; i < methods.length; i++) {
-    var l = this.methods.push(methods[i].toUpperCase());
+  for(let i = 0; i < methods.length; i++) {
+    const l = this.methods.push(methods[i].toUpperCase());
     if (this.methods[l-1] === 'GET') {
        this.methods.unshift('HEAD');
     }
   }
 
   // ensure middleware is a function
-  for (var i = 0; i < this.stack.length; i++) {
-    var fn = this.stack[i];
-    var type = (typeof fn);
+  for (let i = 0; i < this.stack.length; i++) {
+    const fn = this.stack[i];
+    const type = (typeof fn);
     if (type !== 'function') {
       throw new Error(
         methods.toString() + " `" + (this.opts.name || path) +"`: `middleware` "
@@ -73,11 +73,11 @@ Layer.prototype.match = function (path) {
  */
 
 Layer.prototype.params = function (path, captures, existingParams) {
-  var params = existingParams || {};
+  const params = existingParams || {};
 
-  for (var len = captures.length, i=0; i<len; i++) {
+  for (let len = captures.length, i=0; i<len; i++) {
     if (this.paramNames[i]) {
-      var c = captures[i];
+      const c = captures[i];
       params[this.paramNames[i].name] = c ? safeDecodeURIComponent(c) : c;
     }
   }
@@ -115,8 +115,8 @@ Layer.prototype.captures = function (path) {
  */
 
 Layer.prototype.url = function (params, options) {
-  var args = params;
-  var url = this.path.replace(/\(\.\*\)/g, '');
+  let args = params;
+  const url = this.path.replace(/\(\.\*\)/g, '');
 
   if (typeof params != 'object') {
     args = Array.prototype.slice.call(arguments);
@@ -126,14 +126,14 @@ Layer.prototype.url = function (params, options) {
     }
   }
 
-  var toPath = compile(url, options);
-  var replaced;
+  const toPath = compile(url, options);
+  let replaced;
 
-  var tokens = parse(url);
-  var replace = {};
+  const tokens = parse(url);
+  let replace = {};
 
   if (args instanceof Array) {
-    for (var len = tokens.length, i=0, j=0; i<len; i++) {
+    for (let len = tokens.length, i=0, j=0; i<len; i++) {
       if (tokens[i].name) replace[tokens[i].name] = args[j++];
     }
   } else if (tokens.some(token => token.name)) {
@@ -145,7 +145,7 @@ Layer.prototype.url = function (params, options) {
   replaced = toPath(replace);
 
   if (options && options.query) {
-    var replaced = new uri(replaced)
+    replaced = new uri(replaced)
     replaced.search(options.query);
     return replaced.toString();
   }
@@ -177,18 +177,18 @@ Layer.prototype.url = function (params, options) {
  */
 
 Layer.prototype.param = function (param, fn) {
-  var stack = this.stack;
-  var params = this.paramNames;
-  var middleware = function (ctx, next) {
+  const stack = this.stack;
+  const params = this.paramNames;
+  const middleware = function (ctx, next) {
     return fn.call(this, ctx.params[param], ctx, next);
   };
   middleware.param = param;
 
-  var names = params.map(function (p) {
+  const names = params.map(function (p) {
     return p.name;
   });
 
-  var x = names.indexOf(param);
+  const x = names.indexOf(param);
   if (x > -1) {
     // iterate through the stack, to figure out where to place the handler fn
     stack.some(function (fn, i) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,11 +5,11 @@
  * @link https://github.com/alexmingoia/koa-router
  */
 
-var debug = require('debug')('koa-router');
-var compose = require('koa-compose');
-var HttpError = require('http-errors');
-var methods = require('methods');
-var Layer = require('./layer');
+const debug = require('debug')('koa-router');
+const compose = require('koa-compose');
+const HttpError = require('http-errors');
+const methods = require('methods');
+const Layer = require('./layer');
 
 /**
  * @module koa-router
@@ -187,11 +187,9 @@ function Router(opts) {
  * @returns {Router}
  */
 
-for (var i = 0; i < methods.length; i++) {
+for (let i = 0; i < methods.length; i++) {
   function setMethodVerb(method) {
     Router.prototype[method] = function(name, path, middleware) {
-      var middleware;
-
       if (typeof path === "string" || path instanceof RegExp) {
         middleware = Array.prototype.slice.call(arguments, 2);
       } else {
@@ -244,35 +242,35 @@ Router.prototype.del = Router.prototype['delete'];
  */
 
 Router.prototype.use = function () {
-  var router = this;
-  var middleware = Array.prototype.slice.call(arguments);
-  var path;
+  const router = this;
+  const middleware = Array.prototype.slice.call(arguments);
+  let path;
 
   // support array of paths
   if (Array.isArray(middleware[0]) && typeof middleware[0][0] === 'string') {
-    var arrPaths = middleware[0];
-    for (var i = 0; i < arrPaths.length; i++) {
-      var p = arrPaths[i];
+    let arrPaths = middleware[0];
+    for (let i = 0; i < arrPaths.length; i++) {
+      const p = arrPaths[i];
       router.use.apply(router, [p].concat(middleware.slice(1)));
     }
     return this;
   }
 
-  var hasPath = typeof middleware[0] === 'string';
+  const hasPath = typeof middleware[0] === 'string';
   if (hasPath) {
     path = middleware.shift();
   }
 
-  for (var i = 0; i < middleware.length; i++) {
-    var m = middleware[i];
+  for (let i = 0; i < middleware.length; i++) {
+    const m = middleware[i];
     if (m.router) {
-      var cloneRouter = Object.assign(Object.create(Router.prototype), m.router, {
+      const cloneRouter = Object.assign(Object.create(Router.prototype), m.router, {
         stack: m.router.stack.slice(0)
       });
 
-      for (var j = 0; j < cloneRouter.stack.length; j++) {
-        var nestedLayer = cloneRouter.stack[j];
-        var cloneLayer = Object.assign(
+      for (let j = 0; j < cloneRouter.stack.length; j++) {
+        const nestedLayer = cloneRouter.stack[j];
+        const cloneLayer = Object.assign(
           Object.create(Layer.prototype),
           nestedLayer
         );
@@ -285,9 +283,9 @@ Router.prototype.use = function () {
 
       if (router.params) {
         function setRouterParams(paramArr) {
-          var routerParams = paramArr;
-          for (var j = 0; j < routerParams.length; j++) {
-            var key = routerParams[j];
+          const routerParams = paramArr;
+          for (let j = 0; j < routerParams.length; j++) {
+            const key = routerParams[j];
             cloneRouter.param(key, router.params[key]);
           }
         }
@@ -319,11 +317,11 @@ Router.prototype.prefix = function (prefix) {
 
   this.opts.prefix = prefix;
 
-  for (var i = 0; i < this.stack.length; i++) {
-    var route = this.stack[i];
+  for (let i = 0; i < this.stack.length; i++) {
+    const route = this.stack[i];
     route.setPrefix(prefix);
   }
-  
+
   return this;
 };
 
@@ -334,14 +332,14 @@ Router.prototype.prefix = function (prefix) {
  */
 
 Router.prototype.routes = Router.prototype.middleware = function () {
-  var router = this;
+  const router = this;
 
-  var dispatch = function dispatch(ctx, next) {
+  let dispatch = function dispatch(ctx, next) {
     debug('%s %s', ctx.method, ctx.path);
 
-    var path = router.opts.routerPath || ctx.routerPath || ctx.path;
-    var matched = router.match(path, ctx.method);
-    var layerChain, layer, i;
+    const path = router.opts.routerPath || ctx.routerPath || ctx.path;
+    const matched = router.match(path, ctx.method);
+    let layerChain;
 
     if (ctx.matched) {
       ctx.matched.push.apply(ctx.matched, matched.path);
@@ -353,8 +351,8 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (!matched.route) return next();
 
-    var matchedLayers = matched.pathAndMethod
-    var mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
+    const matchedLayers = matched.pathAndMethod
+    const mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
     ctx._matchedRoute = mostSpecificLayer.path;
     if (mostSpecificLayer.name) {
       ctx._matchedRouteName = mostSpecificLayer.name;
@@ -423,26 +421,26 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
 Router.prototype.allowedMethods = function (options) {
   options = options || {};
-  var implemented = this.methods;
+  const implemented = this.methods;
 
   return function allowedMethods(ctx, next) {
     return next().then(function() {
-      var allowed = {};
+      const allowed = {};
 
       if (!ctx.status || ctx.status === 404) {
-        for (var i = 0; i < ctx.matched.length; i++) {
-          var route = ctx.matched[i];
-          for (var j = 0; j < route.methods.length; j++) {
-            var method = route.methods[j];
-              allowed[method] = method
+        for (let i = 0; i < ctx.matched.length; i++) {
+          const route = ctx.matched[i];
+          for (let j = 0; j < route.methods.length; j++) {
+            const method = route.methods[j];
+            allowed[method] = method;
           }
         }
 
-        var allowedArr = Object.keys(allowed);
+        const allowedArr = Object.keys(allowed);
 
         if (!~implemented.indexOf(ctx.method)) {
           if (options.throw) {
-            var notImplementedThrowable;
+            let notImplementedThrowable;
             if (typeof options.notImplemented === 'function') {
               notImplementedThrowable = options.notImplemented(); // set whatever the user returns from their function
             } else {
@@ -460,7 +458,7 @@ Router.prototype.allowedMethods = function (options) {
             ctx.set('Allow', allowedArr.join(', '));
           } else if (!allowed[ctx.method]) {
             if (options.throw) {
-              var notAllowedThrowable;
+              let notAllowedThrowable;
               if (typeof options.methodNotAllowed === 'function') {
                 notAllowedThrowable = options.methodNotAllowed(); // set whatever the user returns from their function
               } else {
@@ -490,8 +488,6 @@ Router.prototype.allowedMethods = function (options) {
  */
 
 Router.prototype.all = function (name, path, middleware) {
-  var middleware;
-
   if (typeof path === 'string') {
     middleware = Array.prototype.slice.call(arguments, 2);
   } else {
@@ -561,13 +557,13 @@ Router.prototype.redirect = function (source, destination, code) {
 Router.prototype.register = function (path, methods, middleware, opts) {
   opts = opts || {};
 
-  var router = this;
-  var stack = this.stack;
+  const router = this;
+  const stack = this.stack;
 
   // support array of paths
   if (Array.isArray(path)) {
-    for (var i = 0; i < path.length; i++) {
-      var curPath = path[i];
+    for (let i = 0; i < path.length; i++) {
+      const curPath = path[i];
       router.register.call(router, curPath, methods, middleware, opts);
     }
 
@@ -575,7 +571,7 @@ Router.prototype.register = function (path, methods, middleware, opts) {
   }
 
   // create route
-  var route = new Layer(path, methods, middleware, {
+  const route = new Layer(path, methods, middleware, {
     end: opts.end === false ? opts.end : true,
     name: opts.name,
     sensitive: opts.sensitive || this.opts.sensitive || false,
@@ -589,8 +585,8 @@ Router.prototype.register = function (path, methods, middleware, opts) {
   }
 
   // add parameter middleware
-  for (var i = 0; i < Object.keys(this.params).length; i++) {
-    var param = Object.keys(this.params)[i];
+  for (let i = 0; i < Object.keys(this.params).length; i++) {
+    const param = Object.keys(this.params)[i];
     route.param(param, this.params[param]);
   }
 
@@ -607,9 +603,9 @@ Router.prototype.register = function (path, methods, middleware, opts) {
  */
 
 Router.prototype.route = function (name) {
-  var routes = this.stack;
+  const routes = this.stack;
 
-  for (var len = routes.length, i=0; i<len; i++) {
+  for (let len = routes.length, i=0; i<len; i++) {
     if (routes[i].name && routes[i].name === name) {
       return routes[i];
     }
@@ -654,10 +650,10 @@ Router.prototype.route = function (name) {
  */
 
 Router.prototype.url = function (name, params) {
-  var route = this.route(name);
+  const route = this.route(name);
 
   if (route) {
-    var args = Array.prototype.slice.call(arguments, 1);
+    const args = Array.prototype.slice.call(arguments, 1);
     return route.url.apply(route, args);
   }
 
@@ -675,15 +671,15 @@ Router.prototype.url = function (name, params) {
  */
 
 Router.prototype.match = function (path, method) {
-  var layers = this.stack;
-  var layer;
-  var matched = {
+  const layers = this.stack;
+  let layer;
+  const matched = {
     path: [],
     pathAndMethod: [],
     route: false
   };
 
-  for (var len = layers.length, i = 0; i < len; i++) {
+  for (let len = layers.length, i = 0; i < len; i++) {
     layer = layers[i];
 
     debug('test %s %s', layer.path, layer.regexp);
@@ -733,8 +729,8 @@ Router.prototype.match = function (path, method) {
 
 Router.prototype.param = function(param, middleware) {
   this.params[param] = middleware;
-  for (var i = 0; i < this.stack.length; i++) {
-    var route = this.stack[i];
+  for (let i = 0; i < this.stack.length; i++) {
+    const route = this.stack[i];
     route.param(param, middleware);
   }
 
@@ -756,6 +752,6 @@ Router.prototype.param = function(param, middleware) {
  * @returns {String}
  */
 Router.url = function (path) {
-    var args = Array.prototype.slice.call(arguments, 1);
+    const args = Array.prototype.slice.call(arguments, 1);
     return Layer.prototype.url.apply({ path: path }, args);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,12 @@
  * Module tests
  */
 
-var koa = require('koa')
-  , should = require('should');
+const koa = require('koa');
+const should = require('should');
 
 describe('module', function() {
   it('should expose Router', function(done) {
-    var Router = require('..');
+    const Router = require('..');
     should.exist(Router);
     Router.should.be.type('function');
     done();

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -2,17 +2,17 @@
  * Route tests
  */
 
-var Koa = require('koa')
-  , http = require('http')
-  , request = require('supertest')
-  , Router = require('../../lib/router')
-  , should = require('should')
-  , Layer = require('../../lib/layer');
+const Koa = require('koa');
+const http = require('http');
+const request = require('supertest');
+const Router = require('../../lib/router');
+const should = require('should');
+const Layer = require('../../lib/layer');
 
 describe('Layer', function() {
   it('composes multiple callbacks/middlware', function(done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     app.use(router.routes());
     router.get(
       '/:category/:title',
@@ -36,8 +36,8 @@ describe('Layer', function() {
 
   describe('Layer#match()', function() {
     it('captures URL path parameters', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get('/:category/:title', function (ctx) {
         ctx.should.have.property('params');
@@ -56,8 +56,8 @@ describe('Layer', function() {
     });
 
     it('return orginal path parameters when decodeURIComponent throw error', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get('/:category/:title', function (ctx) {
         ctx.should.have.property('params');
@@ -73,8 +73,8 @@ describe('Layer', function() {
     });
 
     it('populates ctx.captures with regexp captures', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get(/^\/api\/([^\/]+)\/?/i, function (ctx, next) {
         ctx.should.have.property('captures');
@@ -97,8 +97,8 @@ describe('Layer', function() {
     });
 
     it('return orginal ctx.captures when decodeURIComponent throw error', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get(/^\/api\/([^\/]+)\/?/i, function (ctx, next) {
         ctx.should.have.property('captures');
@@ -121,8 +121,8 @@ describe('Layer', function() {
     });
 
     it('populates ctx.captures with regexp captures include undefiend', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get(/^\/api(\/.+)?/i, function (ctx, next) {
         ctx.should.have.property('captures');
@@ -145,10 +145,10 @@ describe('Layer', function() {
     });
 
     it('should throw friendly error message when handle not exists', function() {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
-      var notexistHandle = undefined;
+      const notexistHandle = undefined;
       (function () {
         router.get('/foo', notexistHandle);
       }).should.throw('get `/foo`: `middleware` must be a function, not `undefined`');
@@ -165,9 +165,9 @@ describe('Layer', function() {
 
   describe('Layer#param()', function() {
     it('composes middleware for param fn', function(done) {
-      var app = new Koa();
-      var router = new Router();
-      var route = new Layer('/users/:user', ['GET'], [function (ctx) {
+      const app = new Koa();
+      const router = new Router();
+      const route = new Layer('/users/:user', ['GET'], [function (ctx) {
         ctx.body = ctx.user;
       }]);
       route.param('user', function (id, ctx, next) {
@@ -189,9 +189,9 @@ describe('Layer', function() {
     });
 
     it('ignores params which are not matched', function(done) {
-      var app = new Koa();
-      var router = new Router();
-      var route = new Layer('/users/:user', ['GET'], [function (ctx) {
+      const app = new Koa();
+      const router = new Router();
+      const route = new Layer('/users/:user', ['GET'], [function (ctx) {
         ctx.body = ctx.user;
       }]);
       route.param('user', function (id, ctx, next) {
@@ -218,7 +218,7 @@ describe('Layer', function() {
     });
 
     it('param with paramNames positive check', function () {
-      var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
+      const route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
       route.paramNames = [{
         name: 'category',
       }]
@@ -230,16 +230,16 @@ describe('Layer', function() {
 
   describe('Layer#url()', function() {
     it('generates route URL', function() {
-      var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
-      var url = route.url({ category: 'programming', title: 'how-to-node' });
+      const route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
+      let url = route.url({ category: 'programming', title: 'how-to-node' });
       url.should.equal('/programming/how-to-node');
       url = route.url('programming', 'how-to-node');
       url.should.equal('/programming/how-to-node');
     });
 
     it('escapes using encodeURIComponent()', function() {
-      var route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
-      var url = route.url(
+      const route = new Layer('/:category/:title', ['get'], [function () {}], {name: 'books'});
+      const url = route.url(
         { category: 'programming', title: 'how to node' },
         { encode: encodeURIComponent }
       );

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -2,30 +2,30 @@
  * Router tests
  */
 
-var fs = require('fs')
-  , http = require('http')
-  , Koa = require('koa')
-  , methods = require('methods')
-  , path = require('path')
-  , request = require('supertest')
-  , Router = require('../../lib/router')
-  , Layer = require('../../lib/layer')
-  , expect = require('expect.js')
-  , should = require('should')
-  , assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const Koa = require('koa');
+const methods = require('methods');
+const path = require('path');
+const request = require('supertest');
+const Router = require('../../lib/router');
+const Layer = require('../../lib/layer');
+const expect = require('expect.js');
+const should = require('should');
+const assert = require('assert');
 
 describe('Router', function () {
   it('creates new router with koa app', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     router.should.be.instanceOf(Router);
     done();
   });
 
   it('shares context between routers (gh-205)', function (done) {
-    var app = new Koa();
-    var router1 = new Router();
-    var router2 = new Router();
+    const app = new Koa();
+    const router1 = new Router();
+    const router2 = new Router();
     router1.get('/', function (ctx, next) {
       ctx.foo = 'bar';
       return next();
@@ -47,9 +47,9 @@ describe('Router', function () {
   });
 
   it('does not register middleware more than once (gh-184)', function (done) {
-    var app = new Koa();
-    var parentRouter = new Router();
-    var nestedRouter = new Router();
+    const app = new Koa();
+    const parentRouter = new Router();
+    const nestedRouter = new Router();
 
     nestedRouter
       .get('/first-nested-route', function (ctx, next) {
@@ -80,8 +80,8 @@ describe('Router', function () {
   });
 
   it('router can be accecced with ctx', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router.get('home', '/', function (ctx) {
           ctx.body = {
             url: ctx.router.url('home')
@@ -99,8 +99,8 @@ describe('Router', function () {
   });
 
   it('registers multiple middleware for one route', function(done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
 
     router.get('/double', function(ctx, next) {
       return new Promise(function(resolve, reject) {
@@ -133,9 +133,9 @@ describe('Router', function () {
   });
 
   it('does not break when nested-routes use regexp paths', function (done) {
-    var app = new Koa();
-    var parentRouter = new Router();
-    var nestedRouter = new Router();
+    const app = new Koa();
+    const parentRouter = new Router();
+    const nestedRouter = new Router();
 
     nestedRouter
       .get(/^\/\w$/i, function (ctx, next) {
@@ -158,20 +158,20 @@ describe('Router', function () {
   });
 
   it('exposes middleware factory', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     router.should.have.property('routes');
     router.routes.should.be.type('function');
-    var middleware = router.routes();
+    const middleware = router.routes();
     should.exist(middleware);
     middleware.should.be.type('function');
     done();
   });
 
   it('supports promises for async/await', function (done) {
-    var app = new Koa();
+    const app = new Koa();
     app.experimental = true;
-    var router = Router();
+    const router = Router();
     router.get('/async', function (ctx, next) {
       return new Promise(function (resolve, reject) {
         setTimeout(function() {
@@ -195,9 +195,9 @@ describe('Router', function () {
   });
 
   it('matches middleware only if route was matched (gh-182)', function (done) {
-    var app = new Koa();
-    var router = new Router();
-    var otherRouter = new Router();
+    const app = new Koa();
+    const router = new Router();
+    const otherRouter = new Router();
 
     router.use(function (ctx, next) {
       ctx.body = { bar: 'baz' };
@@ -222,8 +222,8 @@ describe('Router', function () {
   });
 
   it('matches first to last', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
 
     router
       .get('user_page', '/user/(.*).jsx', function (ctx) {
@@ -247,8 +247,8 @@ describe('Router', function () {
   });
 
   it('does not run subsequent middleware without calling next', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
 
     router
       .get('user_page', '/user/(.*).jsx', function (ctx) {
@@ -264,15 +264,15 @@ describe('Router', function () {
   });
 
   it('nests routers with prefixes at root', function (done) {
-    var app = new Koa();
-    var api = new Router();
-    var forums = new Router({
+    const app = new Koa();
+    const api = new Router();
+    const forums = new Router({
       prefix: '/forums'
     });
-    var posts = new Router({
+    const posts = new Router({
       prefix: '/:fid/posts'
     });
-    var server;
+    let server;
 
     posts
       .get('/', function (ctx, next) {
@@ -315,15 +315,15 @@ describe('Router', function () {
   });
 
   it('nests routers with prefixes at path', function (done) {
-    var app = new Koa();
-    var api = new Router();
-    var forums = new Router({
+    const app = new Koa();
+    const api = new Router();
+    const forums = new Router({
       prefix: '/api'
     });
-    var posts = new Router({
+    const posts = new Router({
       prefix: '/posts'
     });
-    var server;
+    let server;
 
     posts
       .get('/', function (ctx, next) {
@@ -366,8 +366,8 @@ describe('Router', function () {
   });
 
   it('runs subrouter middleware after parent', function (done) {
-    var app = new Koa();
-    var subrouter = Router()
+    const app = new Koa();
+    const subrouter = Router()
       .use(function (ctx, next) {
         ctx.msg = 'subrouter';
         return next();
@@ -375,7 +375,7 @@ describe('Router', function () {
       .get('/', function (ctx) {
         ctx.body = { msg: ctx.msg };
       });
-    var router = Router()
+    const router = Router()
       .use(function (ctx, next) {
         ctx.msg = 'router';
         return next();
@@ -392,12 +392,12 @@ describe('Router', function () {
   });
 
   it('runs parent middleware for subrouter routes', function (done) {
-    var app = new Koa();
-    var subrouter = Router()
+    const app = new Koa();
+    const subrouter = Router()
       .get('/sub', function (ctx) {
         ctx.body = { msg: ctx.msg };
       });
-    var router = Router()
+    const router = Router()
       .use(function (ctx, next) {
         ctx.msg = 'router';
         return next();
@@ -414,8 +414,8 @@ describe('Router', function () {
   });
 
   it('matches corresponding requests', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     app.use(router.routes());
     router.get('/:category/:title', function (ctx) {
       ctx.should.have.property('params');
@@ -428,13 +428,13 @@ describe('Router', function () {
       ctx.params.should.have.property('category', 'programming');
       ctx.status = 204;
     });
-	  router.put('/:category/not-a-title', function (ctx) {
-		  ctx.should.have.property('params');
-		  ctx.params.should.have.property('category', 'programming');
-		  ctx.params.should.not.have.property('title');
-		  ctx.status = 204;
-	  });
-    var server = http.createServer(app.callback());
+    router.put('/:category/not-a-title', function (ctx) {
+      ctx.should.have.property('params');
+      ctx.params.should.have.property('category', 'programming');
+      ctx.params.should.not.have.property('title');
+      ctx.status = 204;
+    });
+    const server = http.createServer(app.callback());
     request(server)
     .get('/programming/how-to-node')
     .expect(204)
@@ -445,19 +445,19 @@ describe('Router', function () {
       .expect(204)
       .end(function (err, res) {
         if (err) return done(err);
-	      request(server)
-		      .put('/programming/not-a-title')
-		      .expect(204)
-		      .end(function (err, res) {
-			      done(err);
-		      });
+        request(server)
+          .put('/programming/not-a-title')
+          .expect(204)
+          .end(function (err, res) {
+            done(err);
+          });
       });
     });
   });
 
   it('executes route middleware using `app.context`', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     app.use(router.routes());
     router.use(function (ctx, next) {
       ctx.bar = 'baz';
@@ -484,9 +484,9 @@ describe('Router', function () {
   });
 
   it('does not match after ctx.throw()', function (done) {
-    var app = new Koa();
-    var counter = 0;
-    var router = new Router();
+    const app = new Koa();
+    let counter = 0;
+    const router = new Router();
     app.use(router.routes());
     router.get('/', function (ctx) {
       counter++;
@@ -495,7 +495,7 @@ describe('Router', function () {
     router.get('/', function () {
       counter++;
     });
-    var server = http.createServer(app.callback());
+    const server = http.createServer(app.callback());
       request(server)
       .get('/')
       .expect(403)
@@ -507,12 +507,12 @@ describe('Router', function () {
   });
 
   it('supports promises for route middleware', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     app.use(router.routes());
-    var readVersion = function () {
+    const readVersion = function () {
       return new Promise(function (resolve, reject) {
-        var packagePath = path.join(__dirname, '..', '..', 'package.json');
+        const packagePath = path.join(__dirname, '..', '..', 'package.json');
         fs.readFile(packagePath, 'utf8', function (err, data) {
           if (err) return reject(err);
           resolve(JSON.parse(data).version);
@@ -535,8 +535,8 @@ describe('Router', function () {
 
   describe('Router#allowedMethods()', function () {
     it('responds to OPTIONS requests', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(router.allowedMethods());
       router.get('/users', function (ctx, next) {});
@@ -553,8 +553,8 @@ describe('Router', function () {
     });
 
     it('responds with 405 Method Not Allowed', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router.get('/users', function () {});
       router.put('/users', function () {});
       router.post('/events', function () {});
@@ -571,8 +571,8 @@ describe('Router', function () {
     });
 
     it('responds with 405 Method Not Allowed using the "throw" option', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(function (ctx, next) {
         return next().catch(function (err) {
@@ -601,8 +601,8 @@ describe('Router', function () {
     });
 
     it('responds with user-provided throwable using the "throw" and "methodNotAllowed" options', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(function (ctx, next) {
         return next().catch(function (err) {
@@ -618,7 +618,7 @@ describe('Router', function () {
       app.use(router.allowedMethods({
         throw: true,
         methodNotAllowed: function () {
-          var notAllowedErr = new Error('Custom Not Allowed Error');
+          const notAllowedErr = new Error('Custom Not Allowed Error');
           notAllowedErr.type = 'custom';
           notAllowedErr.statusCode = 405;
           notAllowedErr.body = {
@@ -648,8 +648,8 @@ describe('Router', function () {
     });
 
     it('responds with 501 Not Implemented', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(router.allowedMethods());
       router.get('/users', function () {});
@@ -664,8 +664,8 @@ describe('Router', function () {
     });
 
     it('responds with 501 Not Implemented using the "throw" option', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(function (ctx, next) {
         return next().catch(function (err) {
@@ -693,8 +693,8 @@ describe('Router', function () {
     });
 
     it('responds with user-provided throwable using the "throw" and "notImplemented" options', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(function (ctx, next) {
         return next().catch(function (err) {
@@ -711,7 +711,7 @@ describe('Router', function () {
       app.use(router.allowedMethods({
         throw: true,
         notImplemented: function () {
-          var notImplementedErr = new Error('Custom Not Implemented Error');
+          const notImplementedErr = new Error('Custom Not Implemented Error');
           notImplementedErr.type = 'custom';
           notImplementedErr.statusCode = 501;
           notImplementedErr.body = {
@@ -740,8 +740,8 @@ describe('Router', function () {
     });
 
     it('does not send 405 if route matched but status is 404', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(router.allowedMethods());
       router.get('/users', function (ctx, next) {
@@ -758,8 +758,8 @@ describe('Router', function () {
 
     it('sets the allowed methods to a single Allow header #273', function (done) {
       // https://tools.ietf.org/html/rfc7231#section-7.4.1
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       app.use(router.allowedMethods());
 
@@ -780,11 +780,11 @@ describe('Router', function () {
   });
 
   it('supports custom routing detect path: ctx.routerPath', function (done) {
-    var app = new Koa();
-    var router = new Router();
+    const app = new Koa();
+    const router = new Router();
     app.use(function (ctx, next) {
       // bind helloworld.example.com/users => example.com/helloworld/users
-      var appname = ctx.request.hostname.split('.', 1)[0];
+      const appname = ctx.request.hostname.split('.', 1)[0];
       ctx.routerPath = '/' + appname + ctx.path;
       return next();
     });
@@ -802,8 +802,8 @@ describe('Router', function () {
 
   describe('Router#[verb]()', function () {
     it('registers route specific to HTTP verb', function () {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       methods.forEach(function (method) {
         router.should.have.property(method);
@@ -814,35 +814,35 @@ describe('Router', function () {
     });
 
     it('registers route with a regexp path', function () {
-      var router = new Router();
+      const router = new Router();
       methods.forEach(function (method) {
         router[method](/^\/\w$/i, function () {}).should.equal(router);
       });
     });
 
     it('registers route with a given name', function () {
-      var router = new Router();
+      const router = new Router();
       methods.forEach(function (method) {
         router[method](method, '/', function () {}).should.equal(router);
       });
     });
 
     it('registers route with with a given name and regexp path', function () {
-      var router = new Router();
+      const router = new Router();
       methods.forEach(function (method) {
         router[method](method, /^\/$/i, function () {}).should.equal(router);
       });
     });
 
     it('enables route chaining', function () {
-      var router = new Router();
+      const router = new Router();
       methods.forEach(function (method) {
         router[method]('/', function () {}).should.equal(router);
       });
     });
 
     it('registers array of paths (gh-203)', function () {
-      var router = new Router();
+      const router = new Router();
       router.get(['/one', '/two'], function (ctx, next) {
         return next();
       });
@@ -852,8 +852,8 @@ describe('Router', function () {
     });
 
     it('resolves non-parameterized routes without attached parameters', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.get('/notparameter', function (ctx, next) {
         ctx.body = {
@@ -883,8 +883,8 @@ describe('Router', function () {
 
   describe('Router#use()', function (done) {
     it('uses router middleware without path', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.use(function (ctx, next) {
         ctx.foo = 'baz';
@@ -915,8 +915,8 @@ describe('Router', function () {
     });
 
     it('uses router middleware at given path', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.use('/foo/bar', function (ctx, next) {
         ctx.foo = 'foo';
@@ -942,9 +942,9 @@ describe('Router', function () {
     });
 
     it('runs router middleware before subrouter middleware', function (done) {
-      var app = new Koa();
-      var router = new Router();
-      var subrouter = new Router();
+      const app = new Koa();
+      const router = new Router();
+      const subrouter = new Router();
 
       router.use(function (ctx, next) {
         ctx.foo = 'boo';
@@ -976,8 +976,8 @@ describe('Router', function () {
     });
 
     it('assigns middleware to array of paths', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.use(['/foo', '/bar'], function (ctx, next) {
         ctx.foo = 'foo';
@@ -1016,8 +1016,8 @@ describe('Router', function () {
     });
 
     it('without path, does not set params.0 to the matched path - gh-247', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.use(function(ctx, next) {
         return next();
@@ -1041,10 +1041,10 @@ describe('Router', function () {
     });
 
     it('does not add an erroneous (.*) to unprefiexed nested routers - gh-369 gh-410', function (done) {
-      var app = new Koa();
-      var router = new Router();
-      var nested = new Router();
-      var called = 0;
+      const app = new Koa();
+      const router = new Router();
+      const nested = new Router();
+      let called = 0;
 
       nested
         .get('/', (ctx, next) => {
@@ -1153,11 +1153,11 @@ describe('Router', function () {
 
   describe('Router#register()', function () {
     it('registers new routes', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router.should.have.property('register');
       router.register.should.be.type('function');
-      var route = router.register('/', ['GET', 'POST'], function () {});
+      const route = router.register('/', ['GET', 'POST'], function () {});
       app.use(router.routes());
       router.stack.should.be.an.instanceOf(Array);
       router.stack.should.have.property('length', 1);
@@ -1168,8 +1168,8 @@ describe('Router', function () {
 
   describe('Router#redirect()', function () {
     it('registers redirect routes', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router.should.have.property('redirect');
       router.redirect.should.be.type('function');
       router.redirect('/source', '/destination', 302);
@@ -1181,8 +1181,8 @@ describe('Router', function () {
     });
 
     it('redirects using route names', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get('home', '/', function () {});
       router.get('sign-up-form', '/sign-up-form', function () {});
@@ -1200,16 +1200,16 @@ describe('Router', function () {
 
   describe('Router#route()', function () {
     it('inherits routes from nested router', function () {
-      var app = new Koa();
-      var subrouter = Router().get('child', '/hello', function (ctx) {
+      const app = new Koa();
+      const subrouter = Router().get('child', '/hello', function (ctx) {
         ctx.body = { hello: 'world' };
       });
-      var router = Router().use(subrouter.routes());
+      const router = Router().use(subrouter.routes());
       expect(router.route('child')).to.have.property('name', 'child');
     });
 
     it('should return false if no name matches', function () {
-      var app = new Koa()
+      const app = new Koa()
       const value = Router().route('Picard')
       value.should.be.false()
     })
@@ -1217,13 +1217,13 @@ describe('Router', function () {
 
   describe('Router#url()', function () {
     it('generates URL for given route name', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router.get('books', '/:category/:title', function (ctx) {
         ctx.status = 204;
       });
-      var url = router.url(
+      let url = router.url(
         'books',
         { category: 'programming', title: 'how to node' },
         { encode: encodeURIComponent }
@@ -1238,12 +1238,12 @@ describe('Router', function () {
     });
 
     it('generates URL for given route name within embedded routers', function (done) {
-        var app = new Koa();
-        var router = new Router({
+        const app = new Koa();
+        const router = new Router({
           prefix: "/books"
         });
 
-        var embeddedRouter = new Router({
+        const embeddedRouter = new Router({
           prefix: "/chapters"
         });
         embeddedRouter.get('chapters', '/:chapterName/:pageNumber', function (ctx) {
@@ -1251,7 +1251,7 @@ describe('Router', function () {
         });
         router.use(embeddedRouter.routes());
         app.use(router.routes());
-        var url = router.url(
+        let url = router.url(
             'chapters',
             { chapterName: 'Learning ECMA6', pageNumber: 123 },
             { encode: encodeURIComponent }
@@ -1265,14 +1265,14 @@ describe('Router', function () {
     });
 
     it('generates URL for given route name within two embedded routers', function (done) {
-      var app = new Koa();
-      var router = new Router({
+      const app = new Koa();
+      const router = new Router({
         prefix: "/books"
       });
-      var embeddedRouter = new Router({
+      const embeddedRouter = new Router({
         prefix: "/chapters"
       });
-      var embeddedRouter2 = new Router({
+      const embeddedRouter2 = new Router({
         prefix: "/:chapterName/pages"
       });
       embeddedRouter2.get('chapters', '/:pageNumber', function (ctx) {
@@ -1281,7 +1281,7 @@ describe('Router', function () {
       embeddedRouter.use(embeddedRouter2.routes());
       router.use(embeddedRouter.routes());
       app.use(router.routes());
-      var url = router.url(
+      const url = router.url(
         'chapters',
         { chapterName: 'Learning ECMA6', pageNumber: 123 },
         { encode: encodeURIComponent }
@@ -1291,21 +1291,21 @@ describe('Router', function () {
     });
 
     it('generates URL for given route name with params and query params', function(done) {
-        var app = new Koa();
-        var router = new Router();
+        const app = new Koa();
+        const router = new Router();
         router.get('books', '/books/:category/:id', function (ctx) {
           ctx.status = 204;
         });
-        var url = router.url('books', 'programming', 4, {
+        let url = router.url('books', 'programming', 4, {
           query: { page: 3, limit: 10 }
         });
         url.should.equal('/books/programming/4?page=3&limit=10');
-        var url = router.url('books',
+        url = router.url('books',
           { category: 'programming', id: 4 },
           { query: { page: 3, limit: 10 }}
         );
         url.should.equal('/books/programming/4?page=3&limit=10');
-        var url = router.url('books',
+        url = router.url('books',
           { category: 'programming', id: 4 },
           { query: 'page=3&limit=10' }
         );
@@ -1314,12 +1314,12 @@ describe('Router', function () {
     })
 
     it('generates URL for given route name without params and query params', function(done) {
-        var app = new Koa();
-        var router = new Router();
+        const app = new Koa();
+        const router = new Router();
         router.get('category', '/category', function (ctx) {
           ctx.status = 204;
         });
-        var url = router.url('category', {
+        const url = router.url('category', {
           query: { page: 3, limit: 10 }
         });
         url.should.equal('/category?page=3&limit=10');
@@ -1342,8 +1342,8 @@ describe('Router', function () {
 
   describe('Router#param()', function () {
     it('runs parameter middleware', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       app.use(router.routes());
       router
         .param('user', function (id, ctx, next) {
@@ -1366,8 +1366,8 @@ describe('Router', function () {
     });
 
     it('runs parameter middleware in order of URL appearance', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router
         .param('user', function (id, ctx, next) {
           ctx.user = { name: 'alex' };
@@ -1405,8 +1405,8 @@ describe('Router', function () {
     });
 
     it('runs parameter middleware in order of URL appearance even when added in random order', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router
         // intentional random order
         .param('a', function (id, ctx, next) {
@@ -1444,9 +1444,9 @@ describe('Router', function () {
     });
 
     it('runs parent parameter middleware for subrouter', function (done) {
-      var app = new Koa();
-      var router = new Router();
-      var subrouter = new Router();
+      const app = new Koa();
+      const router = new Router();
+      const subrouter = new Router();
       subrouter.get('/:cid', function (ctx) {
         ctx.body = {
           id: ctx.params.id,
@@ -1476,8 +1476,8 @@ describe('Router', function () {
 
   describe('Router#opts', function () {
     it('responds with 200', function (done) {
-      var app = new Koa();
-      var router = new Router({
+      const app = new Koa();
+      const router = new Router({
         strict: true
       });
       router.get('/info', function (ctx) {
@@ -1497,8 +1497,8 @@ describe('Router', function () {
     });
 
     it('should allow setting a prefix', function (done) {
-      var app = new Koa();
-      var routes = Router({ prefix: '/things/:thing_id' });
+      const app = new Koa();
+      const routes = Router({ prefix: '/things/:thing_id' });
 
       routes.get('/list', function (ctx) {
         ctx.body = ctx.params;
@@ -1517,8 +1517,8 @@ describe('Router', function () {
     });
 
     it('responds with 404 when has a trailing slash', function (done) {
-      var app = new Koa();
-      var router = new Router({
+      const app = new Koa();
+      const router = new Router({
         strict: true
       });
       router.get('/info', function (ctx) {
@@ -1539,8 +1539,8 @@ describe('Router', function () {
 
   describe('use middleware with opts', function () {
     it('responds with 200', function (done) {
-      var app = new Koa();
-      var router = new Router({
+      const app = new Koa();
+      const router = new Router({
         strict: true
       });
       router.get('/info', function (ctx) {
@@ -1560,8 +1560,8 @@ describe('Router', function () {
     });
 
     it('responds with 404 when has a trailing slash', function (done) {
-      var app = new Koa();
-      var router = new Router({
+      const app = new Koa();
+      const router = new Router({
         strict: true
       });
       router.get('/info', function (ctx) {
@@ -1582,14 +1582,14 @@ describe('Router', function () {
 
   describe('router.routes()', function () {
     it('should return composed middleware', function (done) {
-      var app = new Koa();
-      var router = new Router();
-      var middlewareCount = 0;
-      var middlewareA = function (ctx, next) {
+      const app = new Koa();
+      const router = new Router();
+      let middlewareCount = 0;
+      const middlewareA = function (ctx, next) {
         middlewareCount++;
         return next();
       };
-      var middlewareB = function (ctx, next) {
+      const middlewareB = function (ctx, next) {
         middlewareCount++;
         return next();
       };
@@ -1600,7 +1600,7 @@ describe('Router', function () {
         ctx.body = { hello: 'world' };
       });
 
-      var routerMiddleware = router.routes();
+      const routerMiddleware = router.routes();
 
       expect(routerMiddleware).to.be.a('function');
 
@@ -1620,9 +1620,9 @@ describe('Router', function () {
     });
 
     it('places a `_matchedRoute` value on context', function(done) {
-      var app = new Koa();
-      var router = new Router();
-      var middleware = function (ctx, next) {
+      const app = new Koa();
+      const router = new Router();
+      const middleware = function (ctx, next) {
         expect(ctx._matchedRoute).to.be('/users/:id')
         return next();
       };
@@ -1634,7 +1634,7 @@ describe('Router', function () {
         ctx.body = { hello: 'world' };
       });
 
-      var routerMiddleware = router.routes();
+      const routerMiddleware = router.routes();
 
       request(http.createServer(
         app
@@ -1649,8 +1649,8 @@ describe('Router', function () {
     });
 
     it('places a `_matchedRouteName` value on the context for a named route', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.get('users#show', '/users/:id', function (ctx, next) {
         expect(ctx._matchedRouteName).to.be('users#show')
@@ -1667,8 +1667,8 @@ describe('Router', function () {
     });
 
     it('does not place a `_matchedRouteName` value on the context for unnamed routes', function(done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
 
       router.get('/users/:id', function (ctx, next) {
         expect(ctx._matchedRouteName).to.be(undefined)
@@ -1687,8 +1687,8 @@ describe('Router', function () {
 
   describe('If no HEAD method, default to GET', function () {
     it('should default to GET', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router.get('/users/:id', function (ctx) {
         should.exist(ctx.params.id);
         ctx.body = 'hello';
@@ -1707,8 +1707,8 @@ describe('Router', function () {
     });
 
     it('should work with middleware', function (done) {
-      var app = new Koa();
-      var router = new Router();
+      const app = new Koa();
+      const router = new Router();
       router.get('/users/:id', function (ctx) {
         should.exist(ctx.params.id);
         ctx.body = 'hello';
@@ -1729,19 +1729,19 @@ describe('Router', function () {
 
   describe('Router#prefix', function () {
     it('should set opts.prefix', function () {
-      var router = Router();
+      const router = Router();
       expect(router.opts).to.not.have.key('prefix');
       router.prefix('/things/:thing_id');
       expect(router.opts.prefix).to.equal('/things/:thing_id');
     });
 
     it('should prefix existing routes', function () {
-      var router = Router();
+      const router = Router();
       router.get('/users/:id', function (ctx) {
         ctx.body = 'test';
       })
       router.prefix('/things/:thing_id');
-      var route = router.stack[0];
+      const route = router.stack[0];
       expect(route.path).to.equal('/things/:thing_id/users/:id');
       expect(route.paramNames).to.have.length(2);
       expect(route.paramNames[0]).to.have.property('name', 'thing_id');
@@ -1750,8 +1750,8 @@ describe('Router', function () {
 
     describe('when used with .use(fn) - gh-247', function () {
       it('does not set params.0 to the matched path', function (done) {
-        var app = new Koa();
-        var router = new Router();
+        const app = new Koa();
+        const router = new Router();
 
         router.use(function(ctx, next) {
           return next();
@@ -1782,12 +1782,12 @@ describe('Router', function () {
 
     function testPrefix(prefix) {
       return function () {
-        var server;
-        var middlewareCount = 0;
+        let server;
+        let middlewareCount = 0;
 
         before(function () {
-          var app = new Koa();
-          var router = Router();
+          const app = new Koa();
+          const router = Router();
 
           router.use(function (ctx, next) {
             middlewareCount++;
@@ -1854,13 +1854,13 @@ describe('Router', function () {
     }
 
     it(`prefix and '/' route behavior`, function(done) {
-      var app = new Koa();
-      var router = new Router({
+      const app = new Koa();
+      const router = new Router({
         strict: false,
         prefix: '/foo'
       });
 
-      var strictRouter = new Router({
+      const strictRouter = new Router({
         strict: true,
         prefix: '/bar'
       })
@@ -1876,7 +1876,7 @@ describe('Router', function () {
       app.use(router.routes());
       app.use(strictRouter.routes());
 
-      var server = http.createServer(app.callback());
+      const server = http.createServer(app.callback());
 
       request(server)
         .get('/foo')
@@ -1911,12 +1911,12 @@ describe('Router', function () {
 
   describe('Static Router#url()', function () {
     it('generates route URL', function () {
-        var url = Router.url('/:category/:title', { category: 'programming', title: 'how-to-node' });
+        const url = Router.url('/:category/:title', { category: 'programming', title: 'how-to-node' });
         url.should.equal('/programming/how-to-node');
     });
 
     it('escapes using encodeURIComponent()', function () {
-      var url = Router.url(
+      const url = Router.url(
         '/:category/:title',
         { category: 'programming', title: 'how to node' },
         { encode: encodeURIComponent }
@@ -1925,16 +1925,16 @@ describe('Router', function () {
     });
 
     it('generates route URL with params and query params', function(done) {
-        var url = Router.url('/books/:category/:id', 'programming', 4, {
+        let url = Router.url('/books/:category/:id', 'programming', 4, {
           query: { page: 3, limit: 10 }
         });
         url.should.equal('/books/programming/4?page=3&limit=10');
-        var url = Router.url('/books/:category/:id',
+        url = Router.url('/books/:category/:id',
           { category: 'programming', id: 4 },
           { query: { page: 3, limit: 10 }}
         );
         url.should.equal('/books/programming/4?page=3&limit=10');
-        var url = Router.url('/books/:category/:id',
+        url = Router.url('/books/:category/:id',
           { category: 'programming', id: 4 },
           { query: 'page=3&limit=10' }
         );
@@ -1943,7 +1943,7 @@ describe('Router', function () {
     });
 
     it('generates router URL without params and with with query params', function(done) {
-        var url = Router.url('/category', {
+        const url = Router.url('/category', {
           query: { page: 3, limit: 10 }
         });
         url.should.equal('/category?page=3&limit=10');


### PR DESCRIPTION
Closes #74 
Closes #68 since it incorporates the same change

This is a non-breaking change because the `engines` field in package.json already specifies Node 8+, and `const` and `let` have been fully supported since 6.4.0.