### PR TITLE
improvement: better debug at the end of Router#register

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -1,4 +1,3 @@
-var debug = require('debug')('koa-router');
 var { pathToRegexp, compile, parse } = require('path-to-regexp');
 var uri = require('urijs');
 
@@ -46,8 +45,6 @@ function Layer(path, methods, middleware, opts) {
 
   this.path = path;
   this.regexp = pathToRegexp(path, this.paramNames, this.opts);
-
-  debug('defined route %s %s', this.methods, this.opts.prefix + this.path);
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -596,6 +596,8 @@ Router.prototype.register = function (path, methods, middleware, opts) {
 
   stack.push(route);
 
+  debug('defined route %s %s', route.methods, route.path);
+
   return route;
 };
 


### PR DESCRIPTION
and not Layer#constructor when Router#register can still act upon
the route (Layer) after having debugged it

for the debug to be correct when debugging the special case prefix + '/' because the previous debug happened before the setPrefix call that did the trick