### PR TITLE
Disable Package Lock

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Disables `package-lock.json` from being generated by **npm**.

@niftylettuce are active contributors still being added at collaborators as per the call for maintainers section in the `README`?