### PR TITLE
[WIP] Add routerPath to Context

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -362,6 +362,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
       memo.push(function(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = layer.params(path, ctx.captures, ctx.params);
+        ctx.routerPath = layer.path;
         ctx.routerName = layer.name;
         return next();
       });

--- a/lib/router.js
+++ b/lib/router.js
@@ -362,8 +362,8 @@ Router.prototype.routes = Router.prototype.middleware = function () {
       memo.push(function(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = layer.params(path, ctx.captures, ctx.params);
-        ctx.routerPath = layer.path;
         ctx.routerName = layer.name;
+        ctx.matchedRoute = layer.path;
         return next();
       });
       return memo.concat(layer.stack);

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1648,22 +1648,22 @@ describe('Router', function () {
       });
     });
 
-    it('places a `routerPath` value on context (respects middelware-chains) (gh-34)', function(done) {
+    it('places a `matchedRoute` value on context (gh-34)', function(done) {
       const app = new Koa();
       const router = new Router();
       
       const middleware = async function (ctx, next) {
         await next();
-        expect(ctx.routerPath).to.be('/users/list')
+        expect(ctx.matchedRoute).to.be('/users/list')
       };
 
       router.use(middleware)
       router.get('/users/list', function (ctx, next) {
-        expect(ctx.routerPath).to.be('/users/list')
+        expect(ctx.matchedRoute).to.be('/users/list')
         ctx.body = { hello: 'world' };
       });
       router.get('/users/:id', function (ctx, next) {
-        expect(ctx.routerPath).to.be('/users/:id')
+        expect(ctx.matchedRoute).to.be('/users/:id')
         should.exist(ctx.params.id);
         ctx.body = { hello: 'world' };
       });


### PR DESCRIPTION
Fixes #34 

Though, the `ctx._matchedRoute` fails when handling middleware-chains, i'd go with introducing `ctx.routerPath` instead of replacing it to be consistent with `ctx.routerName` and to not break backwardscompatibility(?). 

To note is, that a Middleware can only know about the "correct" route, after it was hit. This means:

```javascript
// this does not work
const middleware = async function (ctx, next) {
  expect(ctx.routerPath).to.be('/users/list');
  return next();
};
router.use(middleware);

// this works
const middleware = async function (ctx, next) {
  await next();
  expect(ctx.routerPath).to.be('/users/list');
};
router.use(middleware);
```