### PR TITLE
Fix ctx.routerPath causes routes to fail path matches issue

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -364,7 +364,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = ctx.request.params = layer.params(path, ctx.captures, ctx.params);
         ctx.routerPath = layer.path;
-        ctx.routerName = (ctx.params) ? ctx.path : layer.name;
+        ctx.routerName = (ctx.params) ? ctx.path : layer.path;
         ctx._matchedRoute = layer.path;
         if (layer.name) {
           ctx._matchedRouteName = layer.name;

--- a/lib/router.js
+++ b/lib/router.js
@@ -363,8 +363,8 @@ Router.prototype.routes = Router.prototype.middleware = function () {
       memo.push(function(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = ctx.request.params = layer.params(path, ctx.captures, ctx.params);
-        ctx.routerPath = layer.path;
-        ctx.routerName = (ctx.params) ? ctx.path : layer.path;
+        ctx.routerPath = (ctx.params) ? ctx.path : layer.path;
+        ctx.routerName = layer.name;
         ctx._matchedRoute = layer.path;
         if (layer.name) {
           ctx._matchedRouteName = layer.name;

--- a/lib/router.js
+++ b/lib/router.js
@@ -364,7 +364,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = ctx.request.params = layer.params(path, ctx.captures, ctx.params);
         ctx.routerPath = layer.path;
-        ctx.routerName = layer.name;
+        ctx.routerName = (ctx.params) ? ctx.path : layer.name;
         ctx._matchedRoute = layer.path;
         if (layer.name) {
           ctx._matchedRouteName = layer.name;


### PR DESCRIPTION
This PR fixes the issue discussed at https://github.com/koajs/router/issues/101.

If a `ctx.path` contains parameters then do not update `ctx.routerPath` to equal `layer.path`. Instead, keep the original `ctx.path` so future matches can occur.

All tests PASS.