### PR TITLE
Allow router.redirect() to accept external destinations

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -532,7 +532,7 @@ Router.prototype.redirect = function (source, destination, code) {
   if (source[0] !== '/') source = this.url(source);
 
   // lookup destination route by name
-  if (destination[0] !== '/' && !/^.+:\/\//i.test(destination)) destination = this.url(destination);
+  if (destination[0] !== '/' && !/^.+:\/\//.test(destination)) destination = this.url(destination);
 
   return this.all(source, ctx => {
     ctx.redirect(destination);

--- a/lib/router.js
+++ b/lib/router.js
@@ -532,7 +532,7 @@ Router.prototype.redirect = function (source, destination, code) {
   if (source[0] !== '/') source = this.url(source);
 
   // lookup destination route by name
-  if (destination[0] !== '/' && !/^.+:\/\//.test(destination)) destination = this.url(destination);
+  if (destination[0] !== '/' && !destination.includes('://')) destination = this.url(destination);
 
   return this.all(source, ctx => {
     ctx.redirect(destination);

--- a/lib/router.js
+++ b/lib/router.js
@@ -532,7 +532,7 @@ Router.prototype.redirect = function (source, destination, code) {
   if (source[0] !== '/') source = this.url(source);
 
   // lookup destination route by name
-  if (destination[0] !== '/') destination = this.url(destination);
+  if (destination[0] !== '/' && !/^.+:\/\//i.test(destination)) destination = this.url(destination);
 
   return this.all(source, ctx => {
     ctx.redirect(destination);

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1305,6 +1305,36 @@ describe('Router', function () {
           done();
         });
     });
+
+    it('redirects to external sites', function (done) {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      router.redirect('/', 'https://www.example.com');
+      request(http.createServer(app.callback()))
+        .post('/')
+        .expect(301)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.header.should.have.property('location', 'https://www.example.com');
+          done();
+        });
+    });
+
+    it('redirects to any external protocol', function (done) {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      router.redirect('/', 'my-custom-app-protocol://www.example.com/foo');
+      request(http.createServer(app.callback()))
+        .post('/')
+        .expect(301)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.header.should.have.property('location', 'my-custom-app-protocol://www.example.com/foo');
+          done();
+        });
+    });
   });
 
   describe('Router#route()', function () {


### PR DESCRIPTION
Currently `router.redirect()` only accepts route names or absolute URLs. External URLs (e.g. https://www.example.com) will be treated as a route name resulting in a route-not-found error.