### PR TITLE
Allow set router host match

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -44,6 +44,7 @@ module.exports = Router;
  * @alias module:koa-router
  * @param {Object=} opts
  * @param {String=} opts.prefix prefix router paths
+ * @param {String|RegExp=} opts.host host for router match
  * @constructor
  */
 
@@ -63,6 +64,7 @@ function Router(opts) {
 
   this.params = {};
   this.stack = [];
+  this.host = this.opts.host;
 };
 
 /**
@@ -72,7 +74,7 @@ function Router(opts) {
  * Match URL patterns to callback functions or controller actions using `router.verb()`,
  * where **verb** is one of the HTTP verbs such as `router.get()` or `router.post()`.
  *
- * Additionaly, `router.all()` can be used to match against all methods.
+ * Additionally, `router.all()` can be used to match against all methods.
  *
  * ```javascript
  * router
@@ -177,6 +179,24 @@ function Router(opts) {
  *
  * The [path-to-regexp](https://github.com/pillarjs/path-to-regexp) module is
  * used to convert paths to regular expressions.
+ *
+ *
+ * ### Match host for each router instance
+ *
+ * ```javascript
+ * const router = new Router({
+ *    host: 'example.domain' // only match if request host exactly equal `example.domain`
+ * });
+ *
+ * ```
+ *
+ * OR host cloud be a regexp
+ *
+ * ```javascript
+ * const router = new Router({
+ *     host: /.*\.?example\.domain$/ // all host end with .example.domain would be matched
+ * });
+ * ```
  *
  * @name get|put|post|patch|delete|del
  * @memberof module:koa-router.prototype
@@ -337,6 +357,12 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
   let dispatch = function dispatch(ctx, next) {
     debug('%s %s', ctx.method, ctx.path);
+
+    const hostMatched = router.matchHost(ctx.host);
+
+    if (!hostMatched) {
+      return next();
+    }
 
     const path = router.opts.routerPath || ctx.routerPath || ctx.path;
     const matched = router.match(path, ctx.method);
@@ -692,6 +718,32 @@ Router.prototype.match = function (path, method) {
 
   return matched;
 };
+
+/**
+ * Match given `input` to allowed host
+ * @param {String} input
+ * @returns {boolean}
+ */
+
+Router.prototype.matchHost = function (input) {
+  const host = this.host;
+
+  if(!host) {
+    return true;
+  }
+
+  if(!input) {
+    return false;
+  }
+
+  if(typeof host === 'string') {
+    return input === host;
+  }
+
+  if(typeof host === 'object' && host instanceof RegExp) {
+    return host.test(input);
+  }
+}
 
 /**
  * Run middleware for named route parameters. Useful for auto-loading or

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -2235,4 +2235,49 @@ describe('Router', function () {
         done();
     });
   });
+
+  describe('Support host', function () {
+    it('should support host match', function (done) {
+      const app = new Koa();
+      const router = new Router({
+        host: 'test.domain'
+      });
+      router.get('/', (ctx) => {
+        ctx.body = {
+          url: '/'
+        };
+      });
+      app.use(router.routes());
+      request(http.createServer(app.callback()))
+          .get('/')
+          .set('Host', 'test.domain')
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err);
+            expect(res.body.url).to.eql("/");
+            done();
+          });
+    });
+    it('should not match host unexpected', function (done) {
+      const app = new Koa();
+      const router = new Router({
+        host: 'test.domain'
+      });
+      router.get('/', (ctx) => {
+        ctx.body = {
+          url: '/'
+        };
+      });
+      app.use(router.routes());
+      request(http.createServer(app.callback()))
+          .get('/')
+          .set('Host', 'a.domain')
+          .expect(404)
+          .end(function (err, res) {
+            if (err) return done(err);
+            expect(res.body.url).to.be(undefined);
+            done();
+          });
+    })
+  })
 });


### PR DESCRIPTION
```javascript
const router = new Router({
    host: 'example.domain' // host === 'example.domain'
});
```
OR
```javascript
const router = new Router({
    host: /.*\.example\.domain$/
});
```

Just for discussion currently, more test case would complete