### PR TITLE
Correct @hapi/boom usage example

### DIFF
--- a/API.md
+++ b/API.md
@@ -259,7 +259,7 @@ app.use(router.allowedMethods());
 ```javascript
 const Koa = require('koa');
 const Router = require('@koa/router');
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 
 const app = new Koa();
 const router = new Router();
@@ -267,8 +267,8 @@ const router = new Router();
 app.use(router.routes());
 app.use(router.allowedMethods({
   throw: true,
-  notImplemented: () => new Boom.notImplemented(),
-  methodNotAllowed: () => new Boom.methodNotAllowed()
+  notImplemented: () => Boom.notImplemented(),
+  methodNotAllowed: () => Boom.methodNotAllowed()
 }));
 ```
 <a name="module_koa-router--Router+redirect"></a>


### PR DESCRIPTION
With the latest version of @hapi/boom (`v9.1.1`) the `notImplemented` and `methodNotAllowed` properties on the `default` export of the package are not constructors. So there's not need for the keyword `new`.  This also updates the package reference from `boom` => `@hapi/boom`.

RE: https://github.com/koajs/router/issues/127