### PR TITLE
feat: add `exclusive` option

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,6 +31,7 @@ Create a new router.
 | --- | --- | --- |
 | [opts] | <code>Object</code> |  |
 | [opts.prefix] | <code>String</code> | prefix router paths |
+| [opts.exclusive] | <code>Boolean</code> | only run last matched route's controller when there are multiple matches |
 
 **Example**  
 Basic usage:

--- a/lib/router.js
+++ b/lib/router.js
@@ -43,6 +43,7 @@ module.exports = Router;
  *
  * @alias module:koa-router
  * @param {Object=} opts
+ * @param {Boolean=false} opts.exclusive only run last matched route's controller when there are multiple matches
  * @param {String=} opts.prefix prefix router paths
  * @constructor
  */
@@ -60,6 +61,7 @@ function Router(opts) {
     'POST',
     'DELETE'
   ];
+  this.exclusive = !!this.opts.exclusive;
 
   this.params = {};
   this.stack = [];
@@ -359,7 +361,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
       ctx._matchedRouteName = mostSpecificLayer.name;
     }
 
-    layerChain = matchedLayers.reduce(function(memo, layer) {
+    layerChain = (router.exclusive ? [mostSpecificLayer] : matchedLayers).reduce(function(memo, layer) {
       memo.push(function(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = ctx.request.params = layer.params(path, ctx.captures, ctx.params);


### PR DESCRIPTION
closes #95 

This PR introduces an `exclusive` boolean option, that makes the router only execute the most specific layer (last match if i understand correctly) when there are multiple route matches for a request url.
c.f. https://github.com/koajs/router/blob/90dd73c44d0e76db0890b552023711de896c12d3/lib/router.js#L356

It is `false` by default, so as not introduce a breaking change.