### PR TITLE
Ensure `_matchedRoute` is the  most specific route.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -352,23 +352,18 @@ Router.prototype.routes = Router.prototype.middleware = function () {
 
     if (!matched.route) return next();
 
-    const matchedLayers = matched.pathAndMethod
-    const mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
+    const mostSpecificLayer = ctx.matched.find((layer) => layer.methods.includes(ctx.method));
     ctx._matchedRoute = mostSpecificLayer.path;
     if (mostSpecificLayer.name) {
       ctx._matchedRouteName = mostSpecificLayer.name;
     }
 
-    layerChain = matchedLayers.reduce(function(memo, layer) {
+    layerChain = matched.pathAndMethod.reduce(function(memo, layer) {
       memo.push(function(ctx, next) {
         ctx.captures = layer.captures(path, ctx.captures);
         ctx.params = ctx.request.params = layer.params(path, ctx.captures, ctx.params);
         ctx.routerPath = layer.path;
         ctx.routerName = layer.name;
-        ctx._matchedRoute = layer.path;
-        if (layer.name) {
-          ctx._matchedRouteName = layer.name;
-        }
         return next();
       });
       return memo.concat(layer.stack);


### PR DESCRIPTION
Added tests that previously failed.