### PR TITLE
Allow param middleware to access param name

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -177,7 +177,7 @@ Layer.prototype.param = function (param, fn) {
   const stack = this.stack;
   const params = this.paramNames;
   const middleware = function (ctx, next) {
-    return fn.call(this, ctx.params[param], ctx, next);
+    return fn.call(middleware, ctx.params[param], ctx, next);
   };
   middleware.param = param;
 


### PR DESCRIPTION
Change `this` binding of param handler call to the middleware itself, allowing access to param name. This allows for generic param middleware that can be re-used for multiple params.

## Background

Express (used to) support a `param` call signature that included the param name, and this allowed for param middleware that could be applied to multiple params, and act accordingly.  That has been changed, but this feature is useful, and it is annoying that there is no easy access to the param name metadata from inside the param middleware. 

Alternatives do exist, such as a factory that takes the param name to construct the middleware:

```js
function createParamMiddleware(paramName) {
  return function(ctx, next) {
    // from in here, the param name can be accessed
  };
};

router.param('foo', createParamMiddleware('foo'));
```

 However, that duplicates the param name parameter. This can be worked around like this:

```js
function createParamMiddleware(paramName) {
  return [paramName, function(ctx, next) {
    // from in here, the param name can be accessed
  }];
};

router.param(...createParamMiddleware('foo'));
```

But this is a bit too fancy for my preferences. It also makes the factory function have to know about the arguments `param` takes.

If the param name was somehow exposed to the middleware callback, this would be much easier. One option (as implemented) is passing the "middleware" object as the "this" binding:

```js
function genericParamMiddleware(ctx, next) {
  // from in here, the param name can be accessed on `this`
  this.param; // => the param name
};


router.param('foo', genericParamMiddleware); // has access to the param name, 'foo'
```

An alternative would be to pass the param name (as express once did):

```js
function genericParamMiddleware(ctx, next, paramName) {
  // from in here, the param name can be accessed on `this`
  paramName; // => the param name
};


router.param('foo', genericParamMiddleware); // has access to the param name, 'foo'
```

This is a bit more explicit, but the drawback here is maintaining the argument order. If later more metadata about the middleware was desired, that would also need to be added to the arguments list. However, the "explicitness" might be worth it...

Feedback welcome, I hope to start productive discussion about this. :)