### PR TITLE
Replace user with ctx.user in param docs

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -159,7 +159,7 @@ Layer.prototype.url = function (params, options) {
  * router
  *   .param('user', function (id, ctx, next) {
  *     ctx.user = users[id];
- *     if (!user) return ctx.status = 404;
+ *     if (!ctx.user) return ctx.status = 404;
  *     next();
  *   })
  *   .get('/users/:user', function (ctx, next) {


### PR DESCRIPTION
Maybe I'm wrong, but I think `user` should be replaced with `ctx.user`