### PR TITLE
Fix problems caused by routerPath

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -377,6 +377,12 @@ Router.prototype.routes = Router.prototype.middleware = function () {
     return compose(layerChain)(ctx, next);
   };
 
+  function restoreRouterPathAfterLayerMatch(ctx, next) {
+    ctx.routerPath = undefined
+    return next()
+  }
+
+  dispatch = compose([dispatch, restoreRouterPathAfterLayerMatch])
   dispatch.router = this;
 
   return dispatch;

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1867,6 +1867,32 @@ describe('Router', function () {
         });
     });
 
+    it('restore a `routerPath` value after layers match', function (done) {
+      const app = new Koa();
+      const router1 = new Router();
+      const router2 = new Router();
+
+      router1.get('/users/:userId', function (ctx, next) {
+        expect(ctx.routerPath).to.be('/users/:userId')
+        next()
+      });
+      router2.get('/users/:id', function (ctx) {
+        expect(ctx.routerPath).to.be('/users/:id')
+        ctx.body = 'hello, user is ' + ctx.params.id;
+      });
+
+      app.use(router1.routes());
+      app.use(router2.routes());
+      request(http.createServer(app.callback()))
+        .get('/users/123')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.text.should.equal('hello, user is 123');
+          done();
+        });
+    });
+
     it('places a `_matchedRoute` value on the context for current route', function (done) {
       const app = new Koa();
       const router = new Router();


### PR DESCRIPTION
`ctx.params` is unexpectedly affected by other routers

 ```javascript
const Koa = require('koa');
const Router = require('@koa/router');

const app = new Koa();
const router1 = new Router();
const router2 = new Router();

router1.get('/users/:userId', async (ctx, next) => {
  console.log(ctx.params) // got { userId: '123' }
  await next();
});

router2.get('/users/:id', async (ctx, next) => {
  console.log(ctx.params) // got { userId: '123', id: ':userId' }
  ctx.body = 'hello, user is ' + ctx.params.id;
});

app.use(router1.routes());
app.use(router2.routes());

app.listen(3000);
```

send a request
```javascript
const axios = require('axios');

axios
  .get('http://127.0.0.1:3000/users/123')
  .then((ret) => {
    console.log(ret.data);  // got hello, user is :userId
  })
  .catch((err) => {
    console.error(err);
  });
```

what is expected is `hello, user is 123`, instead of `hello, user is :userId`

<br/>

I found that the problem stemmed from this line:

https://github.com/koajs/router/blob/1aead99e0e0fdb8666e9c6fa2f52b0463c622025/lib/router.js#L366

It seems that it has caused a series of problems

**originnal feature imports**
> - https://github.com/ZijianHe/koa-router/pull/73
> - https://github.com/koajs/router/issues/34

**unexpected code import**
> - https://github.com/koajs/router/pull/93

**related pull requests**
> - https://github.com/koajs/router/pull/85
> - https://github.com/koajs/router/pull/102
> - https://github.com/koajs/router/pull/123

**related  issues**
> - https://github.com/koajs/router/issues/126
> - https://github.com/koajs/router/issues/101

<br/>

ctx.params shouldn't have been affected by other routers, this looks like a bug that needs to be fixed for this essential module of the koa ecosystem.

In order not to break compatibility, I choose to restore `ctx.routerPath` after layers match and added corresponding tests