### PR TITLE
fix(lib/test/doc): fix jsdoc and typo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,10 +27,10 @@ npm/yarn and version:
 #### Code sample:
 
 <!-- 
-Provide a code sapmle with THE MINIMUM amount of code to reproduce your issue. 
+Provide a code sample with THE MINIMUM amount of code to reproduce your issue. 
 If you cannot provide a succinct example, please create a small test app that exhibits
 the issue you're experiencing. If you cannot provide this, your issue may not be
-able to be reproduced and thus, we will be unabled to address it.
+able to be reproduced and thus, we will be unable to address it.
 -->
 
 ```js

--- a/API.md
+++ b/API.md
@@ -59,7 +59,7 @@ as `router.get()` or `router.post()`.
 Match URL patterns to callback functions or controller actions using `router.verb()`,
 where **verb** is one of the HTTP verbs such as `router.get()` or `router.post()`.
 
-Additionaly, `router.all()` can be used to match against all methods.
+Additionally, `router.all()` can be used to match against all methods.
 
 ```javascript
 router

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -41,7 +41,7 @@ function Layer(path, methods, middleware, opts) {
 
   this.path = path;
   this.regexp = pathToRegexp(path, this.paramNames, this.opts);
-};
+}
 
 /**
  * Returns whether request `path` matches route.

--- a/lib/router.js
+++ b/lib/router.js
@@ -63,7 +63,7 @@ function Router(opts) {
 
   this.params = {};
   this.stack = [];
-};
+}
 
 /**
  * Create `router.verb()` methods, where *verb* is one of the HTTP verbs such
@@ -72,7 +72,7 @@ function Router(opts) {
  * Match URL patterns to callback functions or controller actions using `router.verb()`,
  * where **verb** is one of the HTTP verbs such as `router.get()` or `router.post()`.
  *
- * Additionaly, `router.all()` can be used to match against all methods.
+ * Additionally, `router.all()` can be used to match against all methods.
  *
  * ```javascript
  * router
@@ -486,7 +486,6 @@ Router.prototype.allowedMethods = function (options) {
  * @param {Function=} middleware You may also pass multiple middleware.
  * @param {Function} callback
  * @returns {Router}
- * @private
  */
 
 Router.prototype.all = function (name, path, middleware) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@
  * Module tests
  */
 
-const koa = require('koa');
 const should = require('should');
 
 describe('module', function() {

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -6,11 +6,10 @@ const Koa = require('koa');
 const http = require('http');
 const request = require('supertest');
 const Router = require('../../lib/router');
-const should = require('should');
 const Layer = require('../../lib/layer');
 
 describe('Layer', function() {
-  it('composes multiple callbacks/middlware', function(done) {
+  it('composes multiple callbacks/middleware', function(done) {
     const app = new Koa();
     const router = new Router();
     app.use(router.routes());
@@ -120,7 +119,7 @@ describe('Layer', function() {
       });
     });
 
-    it('populates ctx.captures with regexp captures include undefiend', function(done) {
+    it('populates ctx.captures with regexp captures include undefined', function(done) {
       const app = new Koa();
       const router = new Router();
       app.use(router.routes());

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -153,7 +153,7 @@ describe('Router', function () {
     }, nestedRouter.routes());
 
     app.use(parentRouter.routes());
-    app.should.be.ok;
+    app.should.be.ok();
     done();
   });
 
@@ -811,7 +811,7 @@ describe('Router', function () {
         .end(function (err, res) {
           if (err) return done(err);
           res.header.should.have.property('allow', 'HEAD, GET');
-          let allowHeaders = res.res.rawHeaders.filter((item) => item == 'Allow');
+          let allowHeaders = res.res.rawHeaders.filter((item) => item === 'Allow');
           expect(allowHeaders.length).to.eql(1);
           done();
         });
@@ -1455,7 +1455,7 @@ describe('Router', function () {
     })
 
     it('generates URL for given route name without params and query params', function (done) {
-      var router = new Router();
+      const router = new Router();
       router.get('books', '/books', function (ctx) {
         ctx.status = 204;
       });
@@ -1480,7 +1480,7 @@ describe('Router', function () {
 
 
     it('generates URL for given route name without params and query params', function (done) {
-      var router = new Router();
+      const router = new Router();
       router.get('category', '/category', function (ctx) {
         ctx.status = 204;
       });
@@ -1955,8 +1955,8 @@ describe('Router', function () {
 
 
     it('populates ctx.params correctly for router prefix (including use)', function (done) {
-      var app = new Koa();
-      var router = new Router({ prefix: '/:category' });
+      const app = new Koa();
+      const router = new Router({ prefix: '/:category' });
       app.use(router.routes());
       router
         .use((ctx, next) => {
@@ -1981,8 +1981,8 @@ describe('Router', function () {
     });
 
     it('populates ctx.params correctly for more complex router prefix (including use)', function (done) {
-      var app = new Koa();
-      var router = new Router({ prefix: '/:category/:color' });
+      const app = new Koa();
+      const router = new Router({ prefix: '/:category/:color' });
       app.use(router.routes());
       router
         .use((ctx, next) => {
@@ -2010,8 +2010,8 @@ describe('Router', function () {
     });
 
     it('populates ctx.params correctly for dynamic and static prefix (including async use)', function (done) {
-      var app = new Koa();
-      var router = new Router({ prefix: '/:ping/pong' });
+      const app = new Koa();
+      const router = new Router({ prefix: '/:ping/pong' });
       app.use(router.routes());
       router
         .use(async (ctx, next) => {
@@ -2036,8 +2036,8 @@ describe('Router', function () {
     });
 
     it('populates ctx.params correctly for static prefix', function (done) {
-      var app = new Koa();
-      var router = new Router({ prefix: '/all' });
+      const app = new Koa();
+      const router = new Router({ prefix: '/all' });
       app.use(router.routes());
       router
         .use((ctx, next) => {


### PR DESCRIPTION
When I read Koa-router's source, I noticed some typo errors in JSDoc and documentation, so I tried to fix them.

By the way, I tried to change some `var` to `const`。