### PR TITLE
Should fix #147

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -189,12 +189,21 @@ function Router(opts) {
 for (let i = 0; i < methods.length; i++) {
   function setMethodVerb(method) {
     Router.prototype[method] = function(name, path, middleware) {
+      // Named route router[method](name, path, middleware)
       if (typeof path === "string" || path instanceof RegExp) {
         middleware = Array.prototype.slice.call(arguments, 2);
-      } else {
+      } 
+      // Unamed route router[method](path, middleware)
+      else if (typeof name === "string" || name instanceof RegExp) {
         middleware = Array.prototype.slice.call(arguments, 1);
         path = name;
         name = null;
+      }
+      // Middleware router[method](middleware)
+      else {
+        middleware = Array.from(arguments)
+        path = /(.)+/g
+        name = null
       }
 
       this.register(path, [method], middleware, {


### PR DESCRIPTION
Rather than removing the support of router middleware, I explicitly added them. The reason we were getting the `Unexpected CHAR at 1, expected END path-to-regexp` error was because for `path-to-regexp` a route handler is also a valid path unless you added more than one parameter. 

I don't see a reason not to support middlewares by default rather than allow users to do wildcards by themselves. 