### PR TITLE
Replace 'or (||)' cond with default params

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -17,8 +17,8 @@ module.exports = Layer;
  * @private
  */
 
-function Layer(path, methods, middleware, opts) {
-  this.opts = opts || {};
+function Layer(path, methods, middleware, opts = {}) {
+  this.opts = opts;
   this.name = this.opts.name || null;
   this.methods = [];
   this.paramNames = [];
@@ -60,14 +60,12 @@ Layer.prototype.match = function (path) {
  *
  * @param {String} path
  * @param {Array.<String>} captures
- * @param {Object=} existingParams
+ * @param {Object=} params
  * @returns {Object}
  * @private
  */
 
-Layer.prototype.params = function (path, captures, existingParams) {
-  const params = existingParams || {};
-
+Layer.prototype.params = function (path, captures, params = {}) {
   for (let len = captures.length, i = 0; i < len; i++) {
     if (this.paramNames[i]) {
       const c = captures[i];

--- a/lib/router.js
+++ b/lib/router.js
@@ -47,10 +47,10 @@ module.exports = Router;
  * @constructor
  */
 
-function Router(opts) {
+function Router(opts = {}) {
   if (!(this instanceof Router)) return new Router(opts);
 
-  this.opts = opts || {};
+  this.opts = opts;
   this.methods = this.opts.methods || [
     'HEAD',
     'OPTIONS',
@@ -425,8 +425,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
  * @returns {Function}
  */
 
-Router.prototype.allowedMethods = function (options) {
-  options = options || {};
+Router.prototype.allowedMethods = function (options = {}) {
   const implemented = this.methods;
 
   return function allowedMethods(ctx, next) {
@@ -550,9 +549,7 @@ Router.prototype.redirect = function (source, destination, code) {
  * @private
  */
 
-Router.prototype.register = function (path, methods, middleware, opts) {
-  opts = opts || {};
-
+Router.prototype.register = function (path, methods, middleware, opts = {}) {
   const router = this;
   const stack = this.stack;
 


### PR DESCRIPTION
Hi,

According or packages.json the minimal version of node js is 8 and it's good because since from version 6 we can use default params for function arguments:
 - [github](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
 - [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
