### PR TITLE
Suggest installing types as dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install @koa/router
 ## Typescript Support
 
 ```sh
-npm install @types/koa__router
+npm install --save-dev @types/koa__router
 ```
 
 


### PR DESCRIPTION
Typescript types are usually only required at build time, and not runtime. But the old instructions would end up with the types being around at run-time.

From the [npm install documentation](https://docs.npmjs.com/cli/v6/commands/npm-install)

> `npm install` saves any specified packages into `dependencies` by default.

## Checklist

- [ ] I have ensured my pull request is not behind the main or master branch of the original repository.
- [ ] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [ ] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [ ] I have described my pull request and the reasons for code changes along with context if necessary.
