### PR TITLE
fix: undefined property in unmatched host

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -483,7 +483,7 @@ Router.prototype.allowedMethods = function (options = {}) {
     return next().then(function () {
       const allowed = {};
 
-      if (!ctx.status || ctx.status === 404) {
+      if (ctx.matched && (!ctx.status || ctx.status === 404)) {
         for (let i = 0; i < ctx.matched.length; i++) {
           const route = ctx.matched[i];
           for (let j = 0; j < route.methods.length; j++) {


### PR DESCRIPTION
`allowedMethods()` throws a runtime error when the `host` of its router fails to match. Additionally it would throw if you never added `routes()` to your koa middleware chain.

Example:
```
import Router from "@koa/router";
import Koa from "koa";

const app = new Koa();
const router = new Router({ host: "aaaa" });
app.use(router.routes());
app.use(router.allowedMethods());
app.listen(8888);
```

```
$ curl localhost:8888/                   
Internal Server Error
```

Error:
```
  TypeError: Cannot read properties of undefined (reading 'length')
      at /Users/marcel/braid/web/.pnpm/@koa+router@12.0.1/node_modules/@koa/router/lib/router.js:487:41
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
