### PR TITLE
fix: bump path-to-regexp to 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "http-errors": "^2.0.0",
     "koa-compose": "^4.1.0",
-    "path-to-regexp": "^6.2.2"
+    "path-to-regexp": "^6.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.2",


### PR DESCRIPTION
Resolves #186

See also https://github.com/pillarjs/path-to-regexp/issues/323

## Checklist

- [X] I have ensured my pull request is not behind the main or master branch of the original repository.
- [X] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [X] I have written a commit message that passes commitlint linting.
- [X] I have ensured that my code changes pass linting tests.
- [X] I have ensured that my code changes pass unit tests.
- [X] I have described my pull request and the reasons for code changes along with context if necessary.
