### PR TITLE
Chore: Add pathIsRegexp option to docs, revert new trailing option as unneeded

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -13,6 +13,7 @@ module.exports = class Layer {
    * @param {String=} opts.name route name
    * @param {String=} opts.sensitive case sensitive (default: false)
    * @param {String=} opts.strict require the trailing slash (default: false)
+   * @param {Boolean=} opts.pathIsRegexp if true, treat `path` as a regular expression
    * @returns {Layer}
    * @private
    */
@@ -45,6 +46,11 @@ module.exports = class Layer {
     if (this.opts.pathIsRegexp === true) {
       this.regexp = new RegExp(path);
     } else if (this.path) {
+      if (this.opts.strict === true) {
+        // path-to-regexp renamed strict to trailing in v8.1.0
+        this.opts.trailing = false;
+      }
+
       const { regexp: regex, keys } = pathToRegexp(this.path, this.opts);
       this.regexp = regex;
       this.paramNames = keys;

--- a/lib/router.js
+++ b/lib/router.js
@@ -481,8 +481,7 @@ class Router {
       strict: opts.strict || false,
       prefix: opts.prefix || '',
       ignoreCaptures: opts.ignoreCaptures,
-      pathIsRegexp: opts.pathIsRegexp,
-      trailing: opts.trailing
+      pathIsRegexp: opts.pathIsRegexp
     });
 
     // if parent prefix exists, add prefix to new route

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1657,7 +1657,7 @@ describe('Router#opts', () => {
   it('responds with 200', async () => {
     const app = new Koa();
     const router = new Router({
-      trailing: false
+      strict: true
     });
     router.get('/info', (ctx) => {
       ctx.body = 'hello';
@@ -1689,7 +1689,7 @@ describe('Router#opts', () => {
   it('responds with 404 when has a trailing slash', async () => {
     const app = new Koa();
     const router = new Router({
-      trailing: false
+      strict: true
     });
     router.get('/info', (ctx) => {
       ctx.body = 'hello';
@@ -1704,7 +1704,7 @@ describe('use middleware with opts', () => {
   it('responds with 200', async () => {
     const app = new Koa();
     const router = new Router({
-      trailing: false
+      strict: true
     });
     router.get('/info', (ctx) => {
       ctx.body = 'hello';
@@ -1720,7 +1720,7 @@ describe('use middleware with opts', () => {
   it('responds with 404 when has a trailing slash', async () => {
     const app = new Koa();
     const router = new Router({
-      trailing: false
+      strict: true
     });
     router.get('/info', (ctx) => {
       ctx.body = 'hello';


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

@titanism PR to add new options to docs.  Apologies, on reading through this again I realized we don't need to add a new "trailing" option.  That trailing option comes from path-to-regexp, but is really just renaming the old strict option. Instead of handling them separately, we should add the trailing option to the Layer options Object, preserving the interface for end users.