### PR TITLE
Revert "Fix: Ensure .use() middleware works when path or prefix contains parameters"

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -44,7 +44,7 @@ module.exports = class Layer {
 
     if (this.opts.pathAsRegExp === true) {
       this.regexp = new RegExp(path);
-    } else {
+    } else if (this.path) {
       if ('strict' in this.opts) {
         // path-to-regexp renamed strict to trailing in v8.1.0
         this.opts.trailing = this.opts.strict !== true;
@@ -224,16 +224,18 @@ module.exports = class Layer {
    * @private
    */
   setPrefix(prefix) {
-    this.path =
-      this.path !== '/' || this.opts.strict === true
-        ? `${prefix}${this.path}`
-        : prefix;
-    if (this.opts.pathAsRegExp === true || prefix instanceof RegExp) {
-      this.regexp = new RegExp(this.path);
-    } else if (this.path) {
-      const { regexp, keys } = pathToRegexp(this.path, this.opts);
-      this.regexp = regexp;
-      this.paramNames = keys;
+    if (this.path) {
+      this.path =
+        this.path !== '/' || this.opts.strict === true
+          ? `${prefix}${this.path}`
+          : prefix;
+      if (this.opts.pathAsRegExp === true || prefix instanceof RegExp) {
+        this.regexp = new RegExp(this.path);
+      } else if (this.path) {
+        const { regexp, keys } = pathToRegexp(this.path, this.opts);
+        this.regexp = regexp;
+        this.paramNames = keys;
+      }
     }
 
     return this;

--- a/lib/router.js
+++ b/lib/router.js
@@ -168,10 +168,10 @@ class Router {
         const routerPrefixHasParam = Boolean(
           router.opts.prefix && keys.length > 0
         );
-        router.register(path || '', [], m, {
+        router.register(path || '([^/]*)', [], m, {
           end: false,
           ignoreCaptures: !hasPath && !routerPrefixHasParam,
-          pathAsRegExp: hasPath ? path instanceof RegExp : false
+          pathAsRegExp: true
         });
       }
     }

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -291,16 +291,34 @@ describe('Layer', () => {
       });
       assert.strictEqual(url, '/programming/how%20to%20node%20%26%20js%2Fts');
     });
+
+    it('setPrefix method checks Layer for path', () => {
+      const route = new Layer('/category', ['get'], [() => {}], {
+        name: 'books'
+      });
+      route.path = '/hunter2';
+      const prefix = route.setPrefix('TEST');
+      assert.strictEqual(prefix.path, 'TEST/hunter2');
+    });
   });
 
   describe('Layer#prefix', () => {
-    it('setPrefix method checks Layer for path', () => {
-      const route = new Layer('/category', ['get'], [() => { }], {
+    it('setPrefix method passes check Layer for path', () => {
+      const route = new Layer('/category', ['get'], [() => {}], {
         name: 'books'
       });
       route.path = '/hunter2';
       const prefix = route.setPrefix('/TEST');
       assert.strictEqual(prefix.path, '/TEST/hunter2');
+    });
+
+    it('setPrefix method fails check Layer for path', () => {
+      const route = new Layer(false, ['get'], [() => {}], {
+        name: 'books'
+      });
+      route.path = false;
+      const prefix = route.setPrefix('/TEST');
+      assert.strictEqual(prefix.path, false);
     });
   });
 });

--- a/test/lib/router.js
+++ b/test/lib/router.js
@@ -1048,27 +1048,6 @@ describe('Router#use()', () => {
     assert.strictEqual(res.body.foobar, 'foobar');
   });
 
-  it('uses router middleware at given path with parameters - koajs/router#gh-202', async () => {
-    const app = new Koa();
-    const router = new Router();
-    router.use('/:foo/:bar', (ctx, next) => {
-      ctx.foo = ctx.params.foo;
-      ctx.bar = ctx.params.bar;
-      return next();
-    });
-    router.get('/:foo/:bar', (ctx) => {
-      ctx.body = {
-        foobar: ctx.foo + ctx.bar
-      };
-    });
-    app.use(router.routes());
-    const res = await request(http.createServer(app.callback()))
-      .get('/qux/baz')
-      .expect(200);
-
-    assert.strictEqual(res.body.foobar, 'quxbaz');
-  });
-
   it('runs router middleware before subrouter middleware', async () => {
     const app = new Koa();
     const router = new Router();
@@ -1932,20 +1911,17 @@ describe('Router#prefix', () => {
         assert.strictEqual('params' in ctx, true);
         assert.strictEqual(typeof ctx.params, 'object');
         assert.strictEqual(ctx.params.category, 'cats');
-        ctx.category = ctx.params.category;
         return next();
       })
       .get('/suffixHere', (ctx) => {
         assert.strictEqual('params' in ctx, true);
         assert.strictEqual(typeof ctx.params, 'object');
         assert.strictEqual(ctx.params.category, 'cats');
-        ctx.status = 200;
-        ctx.body = ctx.category;
+        ctx.status = 204;
       });
-    const res = await request(http.createServer(app.callback()))
+    await request(http.createServer(app.callback()))
       .get('/cats/suffixHere')
-      .expect(200);
-    assert.strictEqual(res.text, 'cats');
+      .expect(204);
   });
 
   it('populates ctx.params correctly for more complex router prefix (including use)', async () => {


### PR DESCRIPTION
Reverts koajs/router#203