### PR TITLE
fix: Make types compatible with Koa Middleware

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,12 @@
  * Type definitions for @koa/router
  */
 
-import type { ParameterizedContext, DefaultContext, DefaultState } from 'koa';
+import type {
+  ParameterizedContext,
+  DefaultContext,
+  DefaultState,
+  Middleware
+} from 'koa';
 import type { RouterInstance as Router } from './router';
 import type Layer from './layer';
 
@@ -249,10 +254,7 @@ export type RouterMiddleware<
   StateT = DefaultState,
   ContextT = DefaultContext,
   BodyT = unknown
-> = (
-  context: RouterContext<StateT, ContextT, BodyT>,
-  next: () => Promise<unknown>
-) => unknown | Promise<unknown>;
+> = Middleware<StateT, RouterContext<StateT, ContextT, BodyT>, BodyT>;
 
 /**
  * HTTP method names in lowercase


### PR DESCRIPTION
Howdy, the latest update has caused some of our types to complain:

https://github.com/seek-oss/skuba/actions/runs/20251074724/job/58142955259#step:5:556

We currently have a generic function:

```
export const createApp = <State, Context>(
  ...middleware: Array<Koa.Middleware<State, Context>>
)

const app = createApp(router.allowedMethods(), router.routes());
```

and we currently get the error:

```
Error: src/app.ts(4,23): error TS2345: Argument of type 'RouterMiddleware<DefaultState, DefaultContext, unknown>' is not assignable to parameter of type 'Middleware<DefaultState, DefaultContext & RouterParameterContext<DefaultState, DefaultContext>, any>'.
  Types of parameters 'context' and 'context' are incompatible.
    Type 'ParameterizedContext<DefaultState, DefaultContext & RouterParameterContext<DefaultState, DefaultContext>, any>' is not assignable to type 'RouterContext<DefaultState, DefaultContext, unknown>'.
      Type 'ParameterizedContext<DefaultState, DefaultContext & RouterParameterContext<DefaultState, DefaultContext>, any>' is not assignable to type '{ request: { params: Record<string, string>; }; routerPath?: string | undefined; routerName?: string | undefined; matched?: Layer<DefaultState, DefaultContext, unknown>[] | undefined; captures?: string[] | undefined; newRouterPath?: string | undefined; _matchedParams?: WeakMap<...> | undefined; }'.
        Types of property 'request' are incompatible.
          Property 'params' is missing in type 'Request' but required in type '{ params: Record<string, string>; }'.
```

This PR makes the new types compatible with the existing types.

Resolves https://github.com/koajs/router/issues/214 too

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
