### PR TITLE
test: failing test for catch-all route example (gh-222)

### DIFF
--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -4020,25 +4020,25 @@ describe('RouterOptions: strict (comprehensive)', () => {
     });
   });
 
-  describe('Catch-all routes (gh-222)', () => {
-    it('catch-all route should return 404 for unmatched routes', async () => {
+  describe('Catch-all routes', () => {
+    it('catch-all route runs for unmatched routes', async () => {
       const app = new Koa();
       const router = new Router();
 
       router.get('/users', (ctx) => {
         ctx.status = 200;
-        ctx.body = { route: 'users' };
+        ctx.body = 'Users';
       });
       router.get('/posts', (ctx) => {
         ctx.status = 200;
-        ctx.body = { route: 'posts' };
+        ctx.body = 'Posts';
       });
 
       // Catch-all for unmatched routes (from README example)
       router.all('{/*rest}', (ctx) => {
         if (!ctx.matched || ctx.matched.length === 0) {
-          ctx.status = 404;
-          ctx.body = { error: 'Not Found' };
+          ctx.status = 200;
+          ctx.body = 'Catch-all';
         }
       });
 
@@ -4047,13 +4047,13 @@ describe('RouterOptions: strict (comprehensive)', () => {
       const server = http.createServer(app.callback());
 
       // Known routes should work normally
-      await request(server).get('/users').expect(200);
-      await request(server).get('/posts').expect(200);
+      await request(server).get('/users').expect(200).expect('Users');
+      await request(server).get('/posts').expect(200).expect('Posts');
 
-      // Unknown route should get 404 from the catch-all
+      // Unknown route should be handled by the catch-all
       const res = await request(server).get('/unknown');
-      assert.strictEqual(res.status, 404);
-      assert.deepStrictEqual(res.body, { error: 'Not Found' });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.text, 'Catch-all');
     });
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -4019,4 +4019,41 @@ describe('RouterOptions: strict (comprehensive)', () => {
       assert.strictEqual(userAccountsRes.body.isAccount, undefined);
     });
   });
+
+  describe('Catch-all routes (gh-222)', () => {
+    it('catch-all route should return 404 for unmatched routes', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.get('/users', (ctx) => {
+        ctx.status = 200;
+        ctx.body = { route: 'users' };
+      });
+      router.get('/posts', (ctx) => {
+        ctx.status = 200;
+        ctx.body = { route: 'posts' };
+      });
+
+      // Catch-all for unmatched routes (from README example)
+      router.all('{/*rest}', (ctx) => {
+        if (!ctx.matched || ctx.matched.length === 0) {
+          ctx.status = 404;
+          ctx.body = { error: 'Not Found' };
+        }
+      });
+
+      app.use(router.routes());
+
+      const server = http.createServer(app.callback());
+
+      // Known routes should work normally
+      await request(server).get('/users').expect(200);
+      await request(server).get('/posts').expect(200);
+
+      // Unknown route should get 404 from the catch-all
+      const res = await request(server).get('/unknown');
+      assert.strictEqual(res.status, 404);
+      assert.deepStrictEqual(res.body, { error: 'Not Found' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a failing test that reproduces the bug described in #222
- The README's catch-all route example uses `ctx.matched.length === 0` to detect unmatched routes, but this never works because the catch-all route itself is always included in `ctx.matched`
- The test uses a `200` response with body `'Catch-all'` to distinguish from Koa's default `404`, making it clear the catch-all handler's conditional body is never reached

## Test plan
- Run `npm run test:core` and observe the new test fails: expects `200 'Catch-all'` but gets Koa's default `404`

Closes #222