### PR TITLE
[exclusive options] add 'best match' algorithm base of number of route params. last in case of equality

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -641,11 +641,14 @@ class RouterImplementation<
     matchedLayers: Layer<StateT, ContextT>[],
     requestPath: string
   ): RouterMiddleware<StateT, ContextT>[] {
-    const layersToExecute = this.opts.exclusive
-      ? [matchedLayers.at(-1)].filter(
-          (layer): layer is Layer<StateT, ContextT> => layer !== undefined
-        )
-      : matchedLayers;
+    let layersToExecute = matchedLayers;
+    if (this.exclusive) {
+      const matchedLayer = matchedLayers
+          // sort items by number of parameters in descending order
+          .toSorted((a, b) => b.paramNames.length - a.paramNames.length)
+          .at(-1);
+      layersToExecute = matchedLayer ? [matchedLayer] : [];
+    }
 
     const middlewareChain: RouterMiddleware<StateT, ContextT>[] = [];
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -275,17 +275,21 @@ describe('Router', () => {
     assert.strictEqual('all' in res.body, true);
   });
 
-  it("runs only the last match when the 'exclusive' option is enabled", async () => {
+  it("runs only the less param match when the 'exclusive' option is enabled", async () => {
     const app = new Koa();
     const router = new Router({ exclusive: true });
 
     router
-      .get('users_single', new RegExp('/users/:id(.*)'), (ctx, next) => {
-        ctx.body = { single: true };
+      .get('users_single', '/users/:id{/*path}', (ctx, next) => {
+        ctx.body = { ...(ctx.body as object), single: true };
         next();
       })
       .get('users_all', '/users/all', (ctx, next) => {
         ctx.body = { ...(ctx.body as object), all: true };
+        next();
+      })
+      .get('any_all', '/:any/all', (ctx, next) => {
+        ctx.body = { ...(ctx.body as object), any: true };
         next();
       });
 
@@ -296,7 +300,32 @@ describe('Router', () => {
       .expect(200);
 
     assert.strictEqual('single' in res.body, false);
+    assert.strictEqual('any' in res.body, false);
     assert.strictEqual('all' in res.body, true);
+  });
+
+  it("runs only the less param match when the 'exclusive' option is enabled - last in case of equality", async () => {
+    const app = new Koa();
+    const router = new Router({ exclusive: true });
+
+    router
+        .get('users_single', '/users/:id', (ctx, next) => {
+          ctx.body = { ...(ctx.body as object), single: true };
+          next();
+        })
+        .get('any_all', '/:any/all', (ctx, next) => {
+          ctx.body = { ...(ctx.body as object), any: true };
+          next();
+        });
+
+    const res = await request(
+        http.createServer(app.use(router.routes()).callback())
+    )
+        .get('/users/all')
+        .expect(200);
+
+    assert.strictEqual('single' in res.body, false);
+    assert.strictEqual('any' in res.body, true);
   });
 
   it('does not run subsequent middleware without calling next', async () => {


### PR DESCRIPTION
Based on OpenApi specification (https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-templating-matching) in case of multiple route matching, the route with the less parameters is supposed to win.

I enrich the `exclusive` option to consider it, with original last choice  in case of equality

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
