### PR TITLE
fix: hide internal rest param from prefixed middleware

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -193,6 +193,13 @@ export default class Layer<
 
       if (parameterDefinition && capturedValue && capturedValue.length > 0) {
         const parameterName = parameterDefinition.name;
+        if (
+          this.opts.ignoreWildcardParameter === parameterName &&
+          parameterDefinition.type === 'wildcard'
+        ) {
+          continue;
+        }
+
         parameterValues[parameterName] = safeDecodeURIComponent(capturedValue);
       }
     }

--- a/src/router.ts
+++ b/src/router.ts
@@ -457,9 +457,15 @@ class RouterImplementation<
       usePathToRegexp = false;
     }
 
+    const ignoreWildcardParameter =
+      effectiveExplicitPath === '' && middlewarePath === '{/*rest}'
+        ? 'rest'
+        : undefined;
+
     this.register(finalPath, [], middleware, {
       end: isRootPath,
       ignoreCaptures: !effectiveHasExplicitPath && !prefixHasParameters,
+      ignoreWildcardParameter,
       pathAsRegExp: usePathToRegexp
     });
   }
@@ -1135,6 +1141,7 @@ class RouterImplementation<
       strict: options.strict || false,
       prefix: options.prefix || '',
       ignoreCaptures: options.ignoreCaptures,
+      ignoreWildcardParameter: options.ignoreWildcardParameter,
       pathAsRegExp: options.pathAsRegExp
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,13 @@ export type LayerOptions = {
   ignoreCaptures?: boolean;
 
   /**
+   * Ignore a generated wildcard route parameter when populating ctx.params
+   *
+   * @internal
+   */
+  ignoreWildcardParameter?: string | number;
+
+  /**
    * Treat path as a regular expression
    */
   pathAsRegExp?: boolean;

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -3122,6 +3122,32 @@ describe('Router#prefix', () => {
       .expect(204);
   });
 
+  it('does not expose internal rest param for prefixed router middleware', async () => {
+    const app = new Koa();
+    const router = new Router({ prefix: '/:id' });
+    const middlewareParams: Record<string, string>[] = [];
+    const routeParams: Record<string, string>[] = [];
+
+    router
+      .use(async (ctx, next) => {
+        middlewareParams.push({ ...ctx.params });
+        await next();
+      })
+      .get('/some-thing', (ctx) => {
+        routeParams.push({ ...ctx.params });
+        ctx.body = ctx.params;
+      });
+
+    app.use(router.routes());
+
+    await request(http.createServer(app.callback()))
+      .get('/1243/some-thing')
+      .expect(200, { id: '1243' });
+
+    assert.deepStrictEqual(middlewareParams, [{ id: '1243' }]);
+    assert.deepStrictEqual(routeParams, [{ id: '1243' }]);
+  });
+
   it('populates ctx.params correctly for more complex router prefix (including use)', async () => {
     const app = new Koa();
     const router = new Router({ prefix: '/:category/:color' });


### PR DESCRIPTION
Fixes #233.

## Summary
- prevent the generated `{/*rest}` wildcard used for prefixed router middleware from being copied into `ctx.params`
- keep prefix params available to both middleware and route handlers
- add a regression test for a parameterized prefix with global middleware and a child route

## Validation
- `npm run ts:check`
- `npm run ts:check:test`
- `npm run lint`
- `npm run build`
- `npm run format:check`
- `git diff --check`
- `$env:TS_NODE_PROJECT='tsconfig.ts-node.json'; node --require ts-node/register --test --test-name-pattern "does not expose internal rest param" test/router.test.ts`
- `$env:TS_NODE_PROJECT='tsconfig.ts-node.json'; node --require ts-node/register --test --test-name-pattern "Router#prefix" test/router.test.ts`
- `$env:TS_NODE_PROJECT='tsconfig.ts-node.json'; node --require ts-node/register --test test/router.test.ts`
- `$env:TS_NODE_PROJECT='tsconfig.ts-node.json'; node --require ts-node/register --test test/layer.test.ts`
- `$env:TS_NODE_PROJECT='tsconfig.ts-node.json'; node --require ts-node/register --test test/utils/*.test.ts`

`npm run test:core` / the pre-commit `test:all` command could not run directly on this Windows shell because the package scripts use POSIX-style `TS_NODE_PROJECT=...` environment assignment. Running the equivalent PowerShell commands above passed for the touched test areas; the full command additionally hit existing Windows shelling failures in `test/index.test.ts` after `npm run build`.