### PR TITLE
fix: support prefixed child middleware under parameterized prefixes

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -559,12 +559,15 @@ export default class Layer<
 
     if (isPrefixHasParameters && isPathIsRawRegex) {
       const currentPath = this.path as string;
-      if (
-        currentPath === String.raw`(?:\/|$)` ||
-        currentPath === String.raw`(?:\\\/|$)`
-      ) {
-        this.path = '{/*rest}';
+      const middlewareBoundary = [
+        String.raw`(?:\/|$)`,
+        String.raw`(?:\\\/|$)`
+      ].find((boundary) => currentPath.endsWith(boundary));
+
+      if (middlewareBoundary) {
+        this.path = `${currentPath.slice(0, -middlewareBoundary.length)}{/*rest}`;
         this.opts.pathAsRegExp = false;
+        this.opts.ignoreWildcardParameter = 'rest';
       }
     }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -490,6 +490,10 @@ class RouterImplementation<
   prefix(prefixPath: string): Router<StateT, ContextT> {
     const normalizedPrefix = prefixPath.replace(/\/$/, '');
     const previousPrefix = this.opts.prefix || '';
+    const isPrefixHasParameters = hasPathParameters(
+      normalizedPrefix,
+      this.opts
+    );
 
     this.opts.prefix = normalizedPrefix;
 
@@ -505,6 +509,10 @@ class RouterImplementation<
       }
 
       route.setPrefix(normalizedPrefix);
+
+      if (route.methods.length === 0 && isPrefixHasParameters) {
+        route.opts.ignoreCaptures = false;
+      }
     }
 
     return this;

--- a/src/router.ts
+++ b/src/router.ts
@@ -329,10 +329,11 @@ class RouterImplementation<
 
     const clonedRouter = this._cloneRouter(nestedRouter);
 
-    const mountPathHasParameters =
-      mountPath &&
-      typeof mountPath === 'string' &&
-      hasPathParameters(mountPath, this.opts);
+    const isMountPathHasParameters =
+      typeof mountPath === 'string' && hasPathParameters(mountPath, this.opts);
+    const isRouterPrefixHasParameters =
+      typeof this.opts.prefix === 'string' &&
+      hasPathParameters(this.opts.prefix, this.opts);
 
     for (
       let routeIndex = 0;
@@ -349,7 +350,10 @@ class RouterImplementation<
         clonedLayer.setPrefix(this.opts.prefix);
       }
 
-      if (clonedLayer.methods.length === 0 && mountPathHasParameters) {
+      if (
+        clonedLayer.methods.length === 0 &&
+        (isMountPathHasParameters || isRouterPrefixHasParameters)
+      ) {
         clonedLayer.opts.ignoreCaptures = false;
       }
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1740,6 +1740,31 @@ it('nested router middleware has access to parent path parameters', async () => 
   assert.strictEqual(res.body.id, '123');
 });
 
+it('mounts prefixed child middleware under a parameterized router prefix', async () => {
+  const app = new Koa();
+  const itemRouter = new Router({ prefix: '/:id' });
+  const childRouter = new Router({ prefix: '/child' });
+  const middlewareParameters: Record<string, string>[] = [];
+
+  childRouter
+    .use(async (ctx, next) => {
+      middlewareParameters.push({ ...ctx.params });
+      await next();
+    })
+    .get('/detail', (ctx) => {
+      ctx.body = ctx.params;
+    });
+
+  itemRouter.use(childRouter.routes());
+  app.use(itemRouter.routes());
+
+  await request(http.createServer(app.callback()))
+    .get('/123/child/detail')
+    .expect(200, { id: '123' });
+
+  assert.deepStrictEqual(middlewareParameters, [{ id: '123' }]);
+});
+
 it('uses a same router middleware at given paths continuously - ZijianHe/koa-router#gh-244 gh-18', async () => {
   const app = new Koa();
   const base = new Router({ prefix: '/api' });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1765,6 +1765,32 @@ it('mounts prefixed child middleware under a parameterized router prefix', async
   assert.deepStrictEqual(middlewareParameters, [{ id: '123' }]);
 });
 
+it('mounts prefixed child middleware before setting a parameterized router prefix', async () => {
+  const app = new Koa();
+  const itemRouter = new Router();
+  const childRouter = new Router({ prefix: '/child' });
+  const middlewareParameters: Record<string, string>[] = [];
+
+  childRouter
+    .use(async (ctx, next) => {
+      middlewareParameters.push({ ...ctx.params });
+      await next();
+    })
+    .get('/detail', (ctx) => {
+      ctx.body = ctx.params;
+    });
+
+  itemRouter.use(childRouter.routes());
+  itemRouter.prefix('/:id');
+  app.use(itemRouter.routes());
+
+  await request(http.createServer(app.callback()))
+    .get('/123/child/detail')
+    .expect(200, { id: '123' });
+
+  assert.deepStrictEqual(middlewareParameters, [{ id: '123' }]);
+});
+
 it('uses a same router middleware at given paths continuously - ZijianHe/koa-router#gh-244 gh-18', async () => {
   const app = new Koa();
   const base = new Router({ prefix: '/api' });


### PR DESCRIPTION
Fixes #244.

## Summary

- preserve a nested child prefix when converting the internal middleware boundary to path-to-regexp v8 syntax
- retain parameters from the parent router prefix for methodless child middleware
- add a regression test for a /:id router mounting a prefixed child router with middleware

## Verification

- yarn test:all (394 passed)
- yarn ts:check
- yarn ts:check:test
- yarn format:check

Tested with Node.js 24.20.0.

## Summary by Sourcery

Fix parameter propagation for prefixed child middleware mounted under parameterized router prefixes.

Bug Fixes:
- Preserve parent route parameters and nested child prefixes for middleware mounted beneath parameterized router prefixes.
- Ensure prefixed child middleware receives parent parameters when routers are configured before or after applying a parameterized prefix.

Tests:
- Add regression coverage for prefixed child middleware mounted under parameterized router prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved routing for parameterized prefixes and nested routers.
  - Path parameters are now correctly preserved and passed to child middleware when routers are mounted under dynamic paths, including when prefixes are applied after mounting.
  - Enhanced handling of raw regular-expression paths with trailing path boundaries, including escaped slash patterns.
  - Methodless child routes now correctly expose parameters inherited from parameterized mount paths and prefixes.

- **Tests**
  - Added coverage for parameter propagation through nested routers with dynamic prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->