### PR TITLE
fix: keep nested child prefixes when converting middleware boundaries

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -559,12 +559,15 @@ export default class Layer<
 
     if (isPrefixHasParameters && isPathIsRawRegex) {
       const currentPath = this.path as string;
-      if (
-        currentPath === String.raw`(?:\/|$)` ||
-        currentPath === String.raw`(?:\\\/|$)`
-      ) {
-        this.path = '{/*rest}';
+      const middlewareBoundary = [
+        String.raw`(?:\/|$)`,
+        String.raw`(?:\\\/|$)`
+      ].find((boundary) => currentPath.endsWith(boundary));
+
+      if (middlewareBoundary) {
+        this.path = `${currentPath.slice(0, -middlewareBoundary.length)}{/*rest}`;
         this.opts.pathAsRegExp = false;
+        this.opts.ignoreWildcardParameter = 'rest';
       }
     }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -329,10 +329,11 @@ class RouterImplementation<
 
     const clonedRouter = this._cloneRouter(nestedRouter);
 
-    const mountPathHasParameters =
-      mountPath &&
-      typeof mountPath === 'string' &&
-      hasPathParameters(mountPath, this.opts);
+    const isMountPathHasParameters =
+      typeof mountPath === 'string' && hasPathParameters(mountPath, this.opts);
+    const isRouterPrefixHasParameters =
+      typeof this.opts.prefix === 'string' &&
+      hasPathParameters(this.opts.prefix, this.opts);
 
     for (
       let routeIndex = 0;
@@ -349,7 +350,10 @@ class RouterImplementation<
         clonedLayer.setPrefix(this.opts.prefix);
       }
 
-      if (clonedLayer.methods.length === 0 && mountPathHasParameters) {
+      if (
+        clonedLayer.methods.length === 0 &&
+        (isMountPathHasParameters || isRouterPrefixHasParameters)
+      ) {
         clonedLayer.opts.ignoreCaptures = false;
       }
 
@@ -486,6 +490,10 @@ class RouterImplementation<
   prefix(prefixPath: string): Router<StateT, ContextT> {
     const normalizedPrefix = prefixPath.replace(/\/$/, '');
     const previousPrefix = this.opts.prefix || '';
+    const isPrefixHasParameters = hasPathParameters(
+      normalizedPrefix,
+      this.opts
+    );
 
     this.opts.prefix = normalizedPrefix;
 
@@ -501,6 +509,10 @@ class RouterImplementation<
       }
 
       route.setPrefix(normalizedPrefix);
+
+      if (route.methods.length === 0 && isPrefixHasParameters) {
+        route.opts.ignoreCaptures = false;
+      }
     }
 
     return this;

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1740,6 +1740,57 @@ it('nested router middleware has access to parent path parameters', async () => 
   assert.strictEqual(res.body.id, '123');
 });
 
+it('mounts prefixed child middleware under a parameterized router prefix', async () => {
+  const app = new Koa();
+  const itemRouter = new Router({ prefix: '/:id' });
+  const childRouter = new Router({ prefix: '/child' });
+  const middlewareParameters: Record<string, string>[] = [];
+
+  childRouter
+    .use(async (ctx, next) => {
+      middlewareParameters.push({ ...ctx.params });
+      await next();
+    })
+    .get('/detail', (ctx) => {
+      ctx.body = ctx.params;
+    });
+
+  itemRouter.use(childRouter.routes());
+  app.use(itemRouter.routes());
+
+  await request(http.createServer(app.callback()))
+    .get('/123/child/detail')
+    .expect(200, { id: '123' });
+
+  assert.deepStrictEqual(middlewareParameters, [{ id: '123' }]);
+});
+
+it('mounts prefixed child middleware before setting a parameterized router prefix', async () => {
+  const app = new Koa();
+  const itemRouter = new Router();
+  const childRouter = new Router({ prefix: '/child' });
+  const middlewareParameters: Record<string, string>[] = [];
+
+  childRouter
+    .use(async (ctx, next) => {
+      middlewareParameters.push({ ...ctx.params });
+      await next();
+    })
+    .get('/detail', (ctx) => {
+      ctx.body = ctx.params;
+    });
+
+  itemRouter.use(childRouter.routes());
+  itemRouter.prefix('/:id');
+  app.use(itemRouter.routes());
+
+  await request(http.createServer(app.callback()))
+    .get('/123/child/detail')
+    .expect(200, { id: '123' });
+
+  assert.deepStrictEqual(middlewareParameters, [{ id: '123' }]);
+});
+
 it('uses a same router middleware at given paths continuously - ZijianHe/koa-router#gh-244 gh-18', async () => {
   const app = new Koa();
   const base = new Router({ prefix: '/api' });


### PR DESCRIPTION
Fixes #244.

When a child router already has a prefix, its middleware path is `/child(?:\/|$)` rather than just the `(?:\/|$)` boundary. Prefixing that with `/:id` handed path-to-regexp a raw `(`, which threw. I'm converting any path that ends with that boundary to `{/*rest}` so the child's prefix is kept, and I'm capturing parent params on methodless layers so nested middleware still sees `ctx.params.id`.

Tests cover mounting under `{ prefix: '/:id' }` and calling `prefix('/:id')` after `use()`.